### PR TITLE
Added constraint relaxation functionality

### DIFF
--- a/src/MILP.js
+++ b/src/MILP.js
@@ -178,8 +178,6 @@ function MILP(model) {
             // Branches with the most promising lower bounds
             // will be picked first
             branches.sort(sortByEvaluation);
-            // branches.sort(sortByNbIntegers);
-            // branches.sort(sortAdvanced);
         }
     }
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -192,7 +192,7 @@ Model.prototype.setCost = function (cost, variable) {
 //-------------------------------------------------------------------
 //-------------------------------------------------------------------
 Model.prototype.loadJson = function (jsonModel) {
-    this.isMinimization = (jsonModel.opType === "min");
+    this.isMinimization = (jsonModel.opType !== "max");
 
     var variables = jsonModel.variables;
     var constraints = jsonModel.constraints;
@@ -216,7 +216,15 @@ Model.prototype.loadJson = function (jsonModel) {
 
         var max = (equal === undefined) ? constraint.max : equal;
         if (max !== undefined) {
-            constraintsMax[constraintId] =  this.smallerThan(max);
+            constraintsMax[constraintId] = this.smallerThan(max);
+        }
+
+        if (equal !== undefined) {
+            var equality = new Equality(constraintsMin[constraintId], constraintsMax[constraintId]);
+            if (constraint.weight !== undefined) {
+                equality.relax(constraint.weight);
+            }
+            continue;
         }
     }
 

--- a/test/constraintRelaxation.js
+++ b/test/constraintRelaxation.js
@@ -1,0 +1,47 @@
+/*global describe*/
+/*global require*/
+/*global module*/
+/*global it*/
+/*global console*/
+/*global process*/
+
+var JSLP = require("../src/solver");
+var Model = JSLP.Model;
+
+//-------------------------------------------
+// IMPOSSIBLE MODEL
+//-------------------------------------------
+var model = new Model(1e-8, "model 1").maximize();
+
+var x1 = model.addVariable(3, "x1");
+var x2 = model.addVariable(5, "x2");
+
+var cst1 = model.equal(8).addTerm(1, x1).addTerm(1, x2);
+var cst2 = model.equal(18).addTerm(3, x1).addTerm(2, x2);
+var cst3 = model.equal(32).addTerm(5, x1).addTerm(4, x2);
+var cst4 = model.equal(4).addTerm(4, x1).addTerm(-1, x2);
+var cst5 = model.greaterThan(6).addTerm(1, x2);
+
+//-------------------------------------------
+// SOLVING ONCE
+//-------------------------------------------
+var solution = model.solve();
+console.log("Is solution feasible?", solution.feasible);
+
+//-------------------------------------------
+// RELAXING CONSTRAINTS
+//-------------------------------------------
+cst1.relax(1);
+cst2.relax(1);
+cst3.relax(1);
+cst4.relax(1);
+
+//-------------------------------------------
+// SOLVING RELAXED MODEL
+//-------------------------------------------
+var solution = model.solve();
+console.log("Constraints relaxed");
+console.log("Is solution feasible?", solution.feasible);
+console.log("Solution", solution);
+
+

--- a/test/dynamicSolving.js
+++ b/test/dynamicSolving.js
@@ -7,9 +7,6 @@
 
 var JSLP = require("../src/solver");
 var Model = JSLP.Model;
-var Tableau = JSLP.Tableau;
-var Term = JSLP.Term;
-
 
 //-------------------------------------------
 // TESTING DYNAMIC RESOLUTION

--- a/test/functionAPI.js
+++ b/test/functionAPI.js
@@ -6,10 +6,7 @@
 /*global process*/
 
 var JSLP = require("../src/solver");
-
 var Model = JSLP.Model;
-var Term = JSLP.Term;
-
 var models = [];
 
 //-------------------------------------------
@@ -39,13 +36,6 @@ var cst1 = model2.greaterThan(3).addTerm(1, x1).addTerm(1, x2);
 var cst2 = model2.greaterThan(4).addTerm(2, x1).addTerm(1, x2);
 
 models.push(model2);
-
-//-------------------------------------------
-// WARM UP
-//-------------------------------------------
-for (var m = 0; m < models.length; m++) {
-    models[m].solve();
-}
 
 //-------------------------------------------
 // TESTING

--- a/test/problems.json
+++ b/test/problems.json
@@ -1,4 +1,41 @@
 [{
+        "name": "Relaxed",
+        "constraints": {
+            "c0": {
+                "equal": 3,
+                "weight": 3
+            },
+            "c1": {
+                "equal": 4,
+                "weight": 2
+            },
+            "c2": {
+                "equal": 0,
+                "weight": 1
+            }
+        },
+        "variables": {
+            "x1": {
+                "c0": 1,
+                "c1": 2,
+                "c2": -3,
+                "objective": 1
+            },
+            "x2": {
+                "c0": 1,
+                "c1": 1,
+                "c2": 1,
+                "objective": 2
+            }
+        },
+        "expects": {
+            "feasible": true,
+            "x1": 0.75,
+            "x2": 2.25,
+            "e2": 0.25,
+            "result": 0.5
+        }
+    }, {
         "name": "Unrestricted",
         "optimize": "objective",
         "opType": "min",


### PR DESCRIPTION
It is possible to make constraints ```soft``` by specifying a weight. An error variable is added to the constraint and to the objective function where the coefficient of the error variable in the objective function corresponds the weight of the constraint.

I had use for this API and this could also help @joshrickert solve his [problem](https://github.com/JWally/jsLPSolver/issues/18).