### PR TITLE
Export and entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "https://github.com/JWally/jsLPSolver"
   },
-  "main": "./src/solver",
+  "main": "./src/main",
   "devDependencies": {
     "benchmark": "*",
     "mocha": "3.1.2",

--- a/src/main.js
+++ b/src/main.js
@@ -163,17 +163,7 @@ var Solver = function () {
 // otherwise, Solver's going global
 /* jshint ignore:start */
 
-(function(){
-    // If define exists; use it
-    if (typeof define === "function") {
-        define([], function () {
-            return new Solver();
-        });
-    } else if(typeof window === "object"){
-        window.solver = new Solver();
-    } else {
-        module.exports =  new Solver();
-    }
-})()
+module.exports = new Solver();
+
 
 /* jshint ignore:end */

--- a/src/main.js
+++ b/src/main.js
@@ -158,12 +158,4 @@ var Solver = function () {
     };
 };
 
-// Determine the environment we're in.
-// if we're in node, offer a friendly exports
-// otherwise, Solver's going global
-/* jshint ignore:start */
-
 module.exports = new Solver();
-
-
-/* jshint ignore:end */

--- a/src/main.js
+++ b/src/main.js
@@ -158,4 +158,8 @@ var Solver = function () {
     };
 };
 
+if (typeof window === "object") {
+    window.solver = new Solver();
+}
+
 module.exports = new Solver();

--- a/src/solver.js
+++ b/src/solver.js
@@ -3199,24 +3199,6 @@ var Solver = function () {
     };
 };
 
-// Determine the environment we're in.
-// if we're in node, offer a friendly exports
-// otherwise, Solver's going global
-/* jshint ignore:start */
-
-(function(){
-    // If define exists; use it
-    if (typeof define === "function") {
-        define([], function () {
-            return new Solver();
-        });
-    } else if(typeof window === "object"){
-        window.solver = new Solver();
-    } else {
-        module.exports =  new Solver();
-    }
-})()
-
-/* jshint ignore:end */
+module.exports = new Solver();
 
 },{"./Model":1,"./Polyopt":2,"./Reformat":3,"./Tableau/branchAndCut":8,"./Tableau/index.js":12,"./Validation":16,"./expressions.js":17}]},{},[18]);

--- a/src/solver.js
+++ b/src/solver.js
@@ -3199,6 +3199,10 @@ var Solver = function () {
     };
 };
 
+if (typeof window === "object") {
+    window.solver = new Solver();
+}
+
 module.exports = new Solver();
 
 },{"./Model":1,"./Polyopt":2,"./Reformat":3,"./Tableau/branchAndCut":8,"./Tableau/index.js":12,"./Validation":16,"./expressions.js":17}]},{},[18]);


### PR DESCRIPTION
This is a small PR to improve the experience of NPM users:
- the entry point has been moved from the browserified solver to the source code. This way it is possible to build (namely browserify) a project that uses the solver.
- @JWally I just erased the environment export system to replace it with a simple ```module.exports```. I did that because of a bug I had after I browserified the solver and some code that need it, together. And then I load everything through an html page. So could you check if the simple export works with all the environment you want to support ?

@JWally last point, after this patch, could you update the version on NPM please ?