### PR TITLE
 Do not show zeros in results

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ which should yield the following:
 ```
 {feasible: true, brit: 24, yank: 20, result: 1080000}
 ```
+
+__Reading the Results__
+
+`feasible`: Whether the solver was able to fulfill all the constraints.
+
+`result`: The value of your optimization variable.
+
+`brit`, `yank`,...: The values of the variables. Note, that variables with the value `0` are not explicitly contained in the result.
+
 What If I Want Only Integers
 --------------------
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mocha": "3.1.2",
     "grunt": "*",
     "grunt-browserify": "^4.0.1",
-    "grunt-contrib-jshint": "~0.9",
+    "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-uglify": "*",
     "grunt-jsbeautifier": "*",
     "grunt-mocha-test": "*",

--- a/src/Tableau/Solution.js
+++ b/src/Tableau/Solution.js
@@ -27,8 +27,13 @@ Solution.prototype.generateSolutionSet = function () {
         }
 
         var varValue = matrix[r][rhsColumn];
-        solutionSet[variable.id] =
-            Math.round(varValue * roundingCoeff) / roundingCoeff;
+        var roundedValue = Math.round(varValue * roundingCoeff) / roundingCoeff;
+
+        if (roundedValue === 0) {
+            continue;
+        }
+
+        solutionSet[variable.id] = roundedValue;
     }
 
     return solutionSet;

--- a/src/solver.js
+++ b/src/solver.js
@@ -608,12 +608,14 @@ function to_JSON(input){
         //"is_int": /^\W{0,}int/i,
         //new version to avoid comments
         "is_int": /^(?!\/\*)\W{0,}int/i,
+        "is_bin": /^(?!\/\*)\W{0,}bin/i,
         "is_constraint": /(\>|\<){0,}\=/i,
         "is_unrestricted": /^\S{0,}unrestricted/i,
         "parse_lhs":  /(\-|\+){0,1}\s{0,1}\d{0,}\.{0,}\d{0,}\s{0,}[A-Za-z]\S{0,}/gi,
         "parse_rhs": /(\-|\+){0,1}\d{1,}\.{0,}\d{0,}\W{0,}\;{0,1}$/i,
         "parse_dir": /(\>|\<){0,}\=/gi,
         "parse_int": /[^\s|^\,]+/gi,
+        "parse_bin": /[^\s|^\,]+/gi,
         "get_num": /(\-|\+){0,1}(\W|^)\d+\.{0,1}\d{0,}/g, // Why accepting character \W before the first digit?
         "get_word": /[A-Za-z].*/
         /* jshint ignore:end */
@@ -707,6 +709,18 @@ function to_JSON(input){
             ary.forEach(function(d){
                 d = d.replace(";","");
                 model.ints[d] = 1;
+            });
+        ////////////////////////////////////
+        } else if(rxo.is_bin.test(tmp)){
+            // Get the array of bins
+            ary = tmp.match(rxo.parse_bin).slice(1);
+
+            // Since we have an binary, our model should too
+            model.binaries = model.binaries || {};
+
+            ary.forEach(function(d){
+                d = d.replace(";","");
+                model.binaries[d] = 1;
             });
         ////////////////////////////////////
         } else if(rxo.is_constraint.test(tmp)){
@@ -905,6 +919,12 @@ Solution.prototype.generateSolutionSet = function () {
         }
 
         var varValue = matrix[r][rhsColumn];
+        var roundedValue = Math.round(varValue * roundingCoeff) / roundingCoeff;
+
+        if (roundedValue === 0) {
+            continue;
+        }
+
         solutionSet[variable.id] =
             Math.round(varValue * roundingCoeff) / roundingCoeff;
     }


### PR DESCRIPTION
I find it confusing, that some variables with value 0 (or -0) appear in the results object returned by `solver.Solve(model)` and some don't. The ones that don't appear are implicitly 0.

This PR explicitly hides variables with value 0 in the results object.