### PR TITLE
Add TypeScript definitions, Part 2

### DIFF
--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -35,6 +35,13 @@ export interface IModelOptions {
     exitOnCycles?: boolean;
 }
 
+export interface IModelExternalSolverOptions {
+    solver: "lpsolve",
+    binPath: string,
+    tempName: string,
+    args: string[]
+}
+
 /**
  * Represents an LP/MILP problem.
  * @typeparam TSolutionVar the decision variables that will be outputed to the `Solution` object.
@@ -81,6 +88,11 @@ export interface IModelBase<TSolutionVar extends string = string, TInternalVar e
      * Options for solving this problem.
      */
     options?: IModelOptions;
+    /**
+     * For server-side JS environment, options for using external solver to solve the model.
+     * @remarks this is still very much in progress and subject to change...
+     */
+    external?: IModelExternalSolverOptions;
 }
 
 /**


### PR DESCRIPTION
Resolves #95, follows #98
* [x] Add members used to solve single objective LP/MILP problem.
* [x] Add members used to solve multi-objective optimization problem.
* [x] Add other sub-modules (or namespaces), if they are intended to be exported and publicized.
    * For now, only exported part of them. Other sub-modules are exported as empty namespace.

I think this makes the type definition almost complete for now.