### PR TITLE
enable usage of lpsolve on LF systems

### DIFF
--- a/src/External/lpsolve/main.js
+++ b/src/External/lpsolve/main.js
@@ -22,10 +22,10 @@ function clean_data(data){
     // Clean Up
     // And Reformatting...
     //
-    data = data.replace("\\r\\n","\r\n");
+    data = data.replace("\\r\\n","\r\n").replace("\r\n","\n");
 
 
-    data = data.split("\r\n");
+    data = data.split("\n");
     data = data.filter(function(x){
         
         var rx;


### PR DESCRIPTION
On systems that don't use LF instead of CRLF for newlines the current `clean_data` function in `src/External/lpsolve/main.js` doesn't correctly split lines.