### PR TITLE
Fix package not being able to be used without WebpackIgnorePlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,18 +42,6 @@ npm install javascript-lp-solver --save
 <script src="https://unpkg.com/javascript-lp-solver/prod/solver.js"></script>
 ```
 
-(webpack)
-```javascript
-const webpack = require('webpack'); //to access built-in plugins
-
-module.exports = {
-        "mode": "development",
-        "plugins": [
-            new webpack.IgnorePlugin(/(fs|child_process)/),
-        ]
-}
-```
-
 ### Use:
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
   },
   "main": "./src/main",
   "types": "./types/main.d.ts",
+  "browser": {                                                                                                                                                                  
+    "fs": false,                                                                                                                                                                
+    "child_process": false                                                                                                                                                      
+  },
   "devDependencies": {
     "benchmark": "*",
     "grunt": "*",


### PR DESCRIPTION
This should mean that bundlers will pick up automatically that you want to ignore "fs" and "child_process".

See here: https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module