### PR TITLE
Fix: variable-name objectives return zero (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Variable-name objectives return zero** - When `optimize` names a variable directly (e.g., `optimize: "x"`) rather than a coefficient attribute, the solver now correctly assigns an implicit cost of 1 to that variable instead of producing a trivial zero objective. ([#121](https://github.com/JWally/jsLPSolver/issues/121), reported by [@Daniel-Alievsky](https://github.com/Daniel-Alievsky))
+
 ## [1.0.1] - 2026-01-12
 
 ### Performance

--- a/src/model.ts
+++ b/src/model.ts
@@ -381,11 +381,24 @@ class Model {
 
         // Instantiating variables and constraint terms
         const objectiveName = jsonModel.optimize as string;
+
+        // Check if objectiveName exists as a coefficient key in any variable.
+        // If not, and it matches a variable name, the user wants to optimize
+        // that variable directly (implicit cost of 1).
+        const objectiveIsAttribute = variableIds.some(
+            (id) => objectiveName in (variables[id] as Record<string, number>)
+        );
+        const objectiveIsVariable = !objectiveIsAttribute && variableIds.includes(objectiveName);
+
         for (let v = 0; v < nVariables; v += 1) {
             // Creation of the variables
             const variableId = variableIds[v];
             const variableConstraints = variables[variableId] as Record<string, number>;
-            const cost = variableConstraints[objectiveName] || 0;
+            const cost = objectiveIsVariable
+                ? variableId === objectiveName
+                    ? 1
+                    : 0
+                : variableConstraints[objectiveName] || 0;
             const isBinary = !!binaryVarIds[variableId];
             const isInteger = !!integerVarIds[variableId] || isBinary;
             const isUnrestricted = !!unrestrictedVarIds[variableId];

--- a/src/solver.integration.test.ts
+++ b/src/solver.integration.test.ts
@@ -141,6 +141,47 @@ describe("Solver Integration Tests", () => {
         });
     });
 
+    describe("Variable-name objectives (issue #121)", () => {
+        it("maximizes a variable when optimize names the variable directly", () => {
+            const model = {
+                optimize: "x",
+                opType: "max" as const,
+                constraints: {
+                    v1: { min: -1, max: 1 },
+                    v2: { min: -1, max: 1 },
+                },
+                variables: {
+                    x: { v1: 1, v2: 1 },
+                    y: { v1: 1, v2: -1 },
+                },
+            };
+
+            const result = solver.Solve(model) as SolveResult;
+            expect(result.feasible).toBe(true);
+            expect(result.result).toBe(1);
+            expect(result.x).toBe(1);
+        });
+
+        it("still uses attribute coefficients when optimize names a coefficient key", () => {
+            const model = {
+                optimize: "profit",
+                opType: "max" as const,
+                constraints: {
+                    budget: { max: 10 },
+                },
+                variables: {
+                    x: { budget: 2, profit: 5 },
+                    y: { budget: 3, profit: 4 },
+                },
+            };
+
+            const result = solver.Solve(model) as SolveResult;
+            expect(result.feasible).toBe(true);
+            expect(result.result).toBe(25);
+            expect(result.x).toBe(5);
+        });
+    });
+
     describe("Test Suite: Sanity Tests", () => {
         const problems = loadTestProblems("test-sanity");
 


### PR DESCRIPTION
## Summary

- When `optimize` names a variable directly (e.g., `optimize: "x"`) but that variable's coefficient map doesn't contain a self-referencing key, the solver now correctly assigns an implicit cost of 1 instead of producing a trivial zero objective.
- Adds regression tests for the fix.
- Adds CHANGELOG entry referencing issue #121 and reporter @Daniel-Alievsky.

Fixes #121

## Test plan

- [x] Existing 386 tests pass
- [x] New regression tests cover both the fix and backward compatibility
- [x] Profile sanity check (47 problems) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)