### PR TITLE
Fix: phase 1 oscillation on degenerate LPs (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Variable-name objectives return zero** - When `optimize` names a variable directly (e.g., `optimize: "x"`) rather than a coefficient attribute, the solver now correctly assigns an implicit cost of 1 to that variable instead of producing a trivial zero objective. ([#121](https://github.com/JWally/jsLPSolver/issues/121), reported by [@Daniel-Alievsky](https://github.com/Daniel-Alievsky))
+- **Solver hangs on degenerate LPs** - Phase 1 of the simplex could oscillate indefinitely on problems with many redundant bound constraints (e.g., 300+ variables with explicit min/max bounds). Now detects non-convergence and falls back to Bland's rule which guarantees termination. ([#112](https://github.com/JWally/jsLPSolver/issues/112), reported by [@luke-thorburn](https://github.com/luke-thorburn))
 
 ## [1.0.1] - 2026-01-12
 

--- a/src/tableau/simplex.ts
+++ b/src/tableau/simplex.ts
@@ -183,15 +183,28 @@ export function phase1(this: Tableau): number {
     const varIndexByRow = this.varIndexByRow;
     const varIndexByCol = this.varIndexByCol;
 
+    // Maximum iterations for the fast max-quotient rule before falling
+    // back. On degenerate problems the max-quotient rule can oscillate, so
+    // we save the matrix and restart with Bland's rule if needed.
+    const maxQuotientLimit = Math.max(lastRow, lastColumn);
+
+    // Save matrix state so we can restart cleanly with Bland's rule
+    const savedMatrix = matrix.slice();
+    const savedVarIndexByRow = this.varIndexByRow.slice();
+    const savedVarIndexByCol = this.varIndexByCol.slice();
+    const savedRowByVarIndex = this.rowByVarIndex.slice();
+    const savedColByVarIndex = this.colByVarIndex.slice();
+
     let unrestricted: boolean;
     let iterations = 0;
+    let useBland = false;
 
     while (true) {
         // Find leaving row (most negative RHS)
         let leavingRowIndex = 0;
         let rhsValue = negPrecision;
         for (let r = 1; r <= lastRow; r++) {
-            const value = matrix[r * width + rhsColumn];
+            const value = this.matrix[r * width + rhsColumn];
             if (value < rhsValue) {
                 rhsValue = value;
                 leavingRowIndex = r;
@@ -203,19 +216,55 @@ export function phase1(this: Tableau): number {
             return iterations;
         }
 
+        // If max-quotient rule hasn't converged, restore matrix and switch
+        // to Bland's rule which guarantees finite termination.
+        if (!useBland && iterations >= maxQuotientLimit) {
+            useBland = true;
+            matrix.set(savedMatrix);
+            for (let i = 0; i < savedVarIndexByRow.length; i++) {
+                varIndexByRow[i] = savedVarIndexByRow[i];
+            }
+            for (let i = 0; i < savedVarIndexByCol.length; i++) {
+                varIndexByCol[i] = savedVarIndexByCol[i];
+            }
+            for (let i = 0; i < savedRowByVarIndex.length; i++) {
+                this.rowByVarIndex[i] = savedRowByVarIndex[i];
+            }
+            for (let i = 0; i < savedColByVarIndex.length; i++) {
+                this.colByVarIndex[i] = savedColByVarIndex[i];
+            }
+            iterations = 0;
+            continue;
+        }
+
         // Find entering column
         let enteringColumn = 0;
-        let maxQuotient = -Infinity;
         const leavingRowOffset = leavingRowIndex * width;
-        for (let c = 1; c <= lastColumn; c++) {
-            const coefficient = matrix[leavingRowOffset + c];
 
-            unrestricted = unrestrictedVars[varIndexByCol[c]] === true;
-            if (unrestricted || coefficient < negPrecision) {
-                const quotient = -matrix[c] / coefficient; // costRowOffset is 0
-                if (maxQuotient < quotient) {
-                    maxQuotient = quotient;
+        if (useBland) {
+            // Bland's rule: pick the first eligible column (smallest index).
+            // Guarantees termination on degenerate problems.
+            for (let c = 1; c <= lastColumn; c++) {
+                const coefficient = matrix[leavingRowOffset + c];
+                unrestricted = unrestrictedVars[varIndexByCol[c]] === true;
+                if (unrestricted || coefficient < negPrecision) {
                     enteringColumn = c;
+                    break;
+                }
+            }
+        } else {
+            // Max-quotient rule: faster in practice but can oscillate on
+            // degenerate problems.
+            let maxQuotient = -Infinity;
+            for (let c = 1; c <= lastColumn; c++) {
+                const coefficient = matrix[leavingRowOffset + c];
+                unrestricted = unrestrictedVars[varIndexByCol[c]] === true;
+                if (unrestricted || coefficient < negPrecision) {
+                    const quotient = -matrix[c] / coefficient;
+                    if (maxQuotient < quotient) {
+                        maxQuotient = quotient;
+                        enteringColumn = c;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Phase 1 of the simplex could oscillate indefinitely on problems with many redundant bound constraints (e.g., 317 variables with explicit `min: 0, max: 1` bounds).
- The max-quotient pivot rule diverges numerically on these degenerate problems, with RHS values blowing up to millions.
- Now saves the initial matrix state and falls back to Bland's rule (smallest-index entering column) if phase 1 hasn't converged within `max(m, n)` iterations. Bland's rule guarantees finite termination.
- The test model from issue #112 (317 vars, 789 constraints) now solves in ~4 seconds instead of hanging forever.

Fixes #112

## Test plan

- [x] Issue #112 model solves correctly (feasible, result: 0.063)
- [x] All 386 existing tests pass
- [x] Profile sanity check (47 problems) passes
- [x] No performance regression (median time improved slightly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)