### PR TITLE
Add JSDoc annotations and fix takeOutOfBase column iteration bug

### DIFF
--- a/src/expressions.ts
+++ b/src/expressions.ts
@@ -14,17 +14,42 @@
  */
 import type Model from "./model";
 
+/**
+ * Priority level for hierarchical optimization.
+ * Numeric values represent custom priority levels (lower = higher priority).
+ * String values map to predefined levels: "required" (0), "strong" (1), "medium" (2), "weak" (3).
+ */
 export type Priority = number | "required" | "strong" | "medium" | "weak";
 
+/**
+ * A continuous decision variable in the optimization problem.
+ *
+ * Variables represent quantities the solver can adjust. Each variable has
+ * an objective coefficient (`cost`), a solution `value`, and a `priority`
+ * level for hierarchical optimization.
+ */
 export class Variable {
+    /** Unique string identifier (used in solution output). */
     id: string;
+    /** Objective function coefficient. */
     cost: number;
+    /** Internal index in the tableau's variable/column arrays. */
     index: number;
+    /** Current solution value (set after solving). */
     value: number;
+    /** Priority level for hierarchical optimization (0 = primary objective). */
     priority: number;
+    /** Whether this variable is restricted to integer values. */
     isInteger?: true;
+    /** Whether this is a slack variable (internal, not a decision variable). */
     isSlack?: true;
 
+    /**
+     * @param id - Unique identifier for this variable.
+     * @param cost - Objective function coefficient.
+     * @param index - Internal tableau index.
+     * @param priority - Priority level for hierarchical optimization.
+     */
     constructor(id: string, cost: number, index: number, priority: number) {
         this.id = id;
         this.cost = cost;
@@ -34,6 +59,10 @@ export class Variable {
     }
 }
 
+/**
+ * A decision variable restricted to integer values.
+ * The branch-and-cut algorithm ensures integrality in the final solution.
+ */
 export class IntegerVariable extends Variable {
     isInteger: true = true;
 
@@ -42,16 +71,29 @@ export class IntegerVariable extends Variable {
     }
 }
 
+/**
+ * An internal variable added to convert inequality constraints to equalities.
+ * Slack variables have zero cost and priority and are excluded from solution output.
+ */
 export class SlackVariable extends Variable {
     isSlack: true = true;
 
+    /**
+     * @param id - Identifier (typically "s" + index).
+     * @param index - Internal tableau index.
+     */
     constructor(id: string, index: number) {
         super(id, 0, index, 0);
     }
 }
 
+/**
+ * A single term in a linear expression: a variable multiplied by a coefficient.
+ */
 export class Term {
+    /** The variable in this term. */
     variable: Variable;
+    /** The scalar multiplier for the variable. */
     coefficient: number;
 
     constructor(variable: Variable, coefficient: number) {
@@ -70,6 +112,17 @@ type RelaxationModel = Model & {
     ): Variable;
 };
 
+/**
+ * Create a relaxation variable for a soft constraint.
+ *
+ * Relaxation variables allow constraints to be violated at a cost in the objective.
+ * The `weight` controls how expensive violation is; `priority` controls hierarchical ordering.
+ *
+ * @param model - The model to add the relaxation variable to.
+ * @param weight - Cost per unit of constraint violation (default: 1).
+ * @param priority - Priority level; "required" (or 0) means no relaxation is created.
+ * @returns The relaxation variable, or null if priority is "required".
+ */
 export function createRelaxationVariable(
     model: RelaxationModel,
     weight?: number,
@@ -93,16 +146,44 @@ export function createRelaxationVariable(
     );
 }
 
+/**
+ * A linear inequality constraint: sum(terms) <= rhs (upper bound) or sum(terms) >= rhs (lower bound).
+ *
+ * Constraints are created via `model.smallerThan()` or `model.greaterThan()` and populated
+ * with terms via the fluent `addTerm()` method. Internally, the constraint is stored
+ * in standard form with a slack variable.
+ *
+ * @example
+ * ```ts
+ * // x + 2y <= 10
+ * const c = model.smallerThan(10);
+ * c.addTerm(1, x).addTerm(2, y);
+ * ```
+ */
 export class Constraint {
+    /** Slack variable converting this inequality to an equality for the tableau. */
     slack: SlackVariable;
+    /** Internal constraint index in the tableau. */
     index: number;
+    /** Reference to the parent model (used for dynamic coefficient updates). */
     model: RelaxationModel;
+    /** Right-hand side value. */
     rhs: number;
+    /** If true, this is a <= constraint; if false, a >= constraint. */
     isUpperBound: boolean;
+    /** All terms on the left-hand side. */
     terms: Term[];
+    /** Fast lookup of terms by variable index for coefficient updates. */
     termsByVarIndex: Record<number, Term>;
+    /** Relaxation variable for soft constraint violation (null if hard). */
     relaxation: Variable | null;
 
+    /**
+     * @param rhs - Right-hand side value.
+     * @param isUpperBound - True for <= constraint, false for >=.
+     * @param index - Internal index assigned by the tableau.
+     * @param model - Parent model for registering coefficient updates.
+     */
     constructor(rhs: number, isUpperBound: boolean, index: number, model: RelaxationModel) {
         this.slack = new SlackVariable("s" + index, index);
         this.index = index;
@@ -116,6 +197,14 @@ export class Constraint {
         this.relaxation = null;
     }
 
+    /**
+     * Add a term (coefficient * variable) to this constraint.
+     * If the variable already has a term, the coefficients are summed.
+     *
+     * @param coefficient - Scalar multiplier for the variable.
+     * @param variable - The decision variable.
+     * @returns This constraint for method chaining.
+     */
     addTerm(coefficient: number, variable: Variable): this {
         const varIndex = variable.index;
         const term = this.termsByVarIndex[varIndex];
@@ -136,11 +225,18 @@ export class Constraint {
         return this;
     }
 
-    // TODO: Implement term removal if required by consumers.
+    /** @deprecated Not yet implemented. Placeholder for future term removal. */
     removeTerm(_term: Term): this {
         return this;
     }
 
+    /**
+     * Update the right-hand side value of this constraint.
+     * Propagates the change to the tableau if already initialized.
+     *
+     * @param newRhs - New RHS value.
+     * @returns This constraint for method chaining.
+     */
     setRightHandSide(newRhs: number): this {
         if (newRhs !== this.rhs) {
             let difference = newRhs - this.rhs;
@@ -155,6 +251,14 @@ export class Constraint {
         return this;
     }
 
+    /**
+     * Set the coefficient of a variable in this constraint.
+     * Creates a new term if the variable doesn't already appear.
+     *
+     * @param newCoefficient - The new coefficient value.
+     * @param variable - The variable whose coefficient to set.
+     * @returns This constraint for chaining, or void if the variable has no index.
+     */
     setVariableCoefficient(newCoefficient: number, variable: Variable): this | void {
         const varIndex = variable.index;
         if (varIndex === -1) {
@@ -184,11 +288,22 @@ export class Constraint {
         return this;
     }
 
+    /**
+     * Make this constraint "soft" by adding a relaxation variable.
+     * Violation of the constraint incurs a penalty in the objective.
+     *
+     * @param weight - Cost per unit of violation (default: 1).
+     * @param priority - Priority level for hierarchical optimization.
+     */
     relax(weight?: number, priority?: Priority): void {
         this.relaxation = createRelaxationVariable(this.model, weight, priority);
         this._relax(this.relaxation);
     }
 
+    /**
+     * Apply a relaxation variable to this constraint.
+     * Adds the variable with coefficient +1 (lower bound) or -1 (upper bound).
+     */
     _relax(relaxationVariable: Variable | null): void {
         if (relaxationVariable === null) {
             // Relaxation variable not created, priority was probably "required"
@@ -203,12 +318,24 @@ export class Constraint {
     }
 }
 
+/**
+ * An equality constraint represented as two paired inequalities (upper + lower bound).
+ *
+ * Created via `model.equal(rhs)`. Operations like `addTerm()` and `relax()` are
+ * delegated to both underlying constraints simultaneously.
+ */
 export class Equality {
+    /** The <= constraint (sum <= rhs). */
     upperBound: Constraint;
+    /** The >= constraint (sum >= rhs). */
     lowerBound: Constraint;
+    /** Reference to the parent model. */
     model: RelaxationModel;
+    /** Right-hand side value (same for both bounds). */
     rhs: number;
+    /** Shared relaxation variable (null if hard constraint). */
     relaxation: Variable | null;
+    /** Type discriminator for distinguishing Equality from Constraint. */
     isEquality: true = true;
 
     constructor(constraintUpper: Constraint, constraintLower: Constraint) {
@@ -219,25 +346,40 @@ export class Equality {
         this.relaxation = null;
     }
 
+    /**
+     * Add a term to both sides of the equality.
+     * @param coefficient - Scalar multiplier.
+     * @param variable - The decision variable.
+     * @returns This equality for method chaining.
+     */
     addTerm(coefficient: number, variable: Variable): this {
         this.upperBound.addTerm(coefficient, variable);
         this.lowerBound.addTerm(coefficient, variable);
         return this;
     }
 
-    // TODO: Implement term removal if required by consumers.
+    /** @deprecated Not yet implemented. Placeholder for future term removal. */
     removeTerm(_term: Term): this {
         this.upperBound.removeTerm(_term);
         this.lowerBound.removeTerm(_term);
         return this;
     }
 
+    /**
+     * Update the RHS value for both inequality constraints.
+     * @param rhs - New right-hand side value.
+     */
     setRightHandSide(rhs: number): void {
         this.upperBound.setRightHandSide(rhs);
         this.lowerBound.setRightHandSide(rhs);
         this.rhs = rhs;
     }
 
+    /**
+     * Make this equality constraint soft by adding a shared relaxation variable to both bounds.
+     * @param weight - Cost per unit of violation.
+     * @param priority - Priority level for hierarchical optimization.
+     */
     relax(weight?: number, priority?: Priority): void {
         this.relaxation = createRelaxationVariable(this.model, weight, priority);
         this.upperBound.relaxation = this.relaxation;
@@ -247,7 +389,11 @@ export class Equality {
     }
 }
 
+/**
+ * A wrapped numeric constant, used for expression building APIs.
+ */
 export class Numeral {
+    /** The numeric value. */
     value: number;
 
     constructor(value: number) {

--- a/src/external/lpsolve/main.js
+++ b/src/external/lpsolve/main.js
@@ -21,6 +21,15 @@
 
 exports.reformat = require("./reformat.js");
 
+/**
+ * Parse lp_solve text output into a key-value result object.
+ *
+ * Filters out zero-valued variables and lines that don't end with a number,
+ * then splits each remaining line into variable name and value.
+ *
+ * @param {string} data - Raw stdout from the lp_solve process.
+ * @returns {Record<string, string>} Map of variable names to their string values.
+ */
 function clean_data(data) {
     //
     // Clean Up
@@ -60,6 +69,15 @@ function clean_data(data) {
     return data;
 }
 
+/**
+ * Solve a model using the lp_solve CLI binary.
+ *
+ * Converts the JSON model to LP format, writes it to a temp file, executes
+ * lp_solve with the specified arguments, and parses the output.
+ *
+ * @param {object} model - The model definition with `external.binPath`, `external.args`, and `external.tempName`.
+ * @returns {Promise<Record<string, string>>} Resolves with variable values on success; rejects with error details.
+ */
 exports.solve = function (model) {
     //
     return new Promise(function (res, rej) {

--- a/src/external/lpsolve/reformat.js
+++ b/src/external/lpsolve/reformat.js
@@ -17,6 +17,15 @@
 /*global console*/
 /*global process*/
 /*jshint -W083 */
+/**
+ * Parse LP format text into a JSON model definition.
+ *
+ * Supports objectives (max/min), inequality/equality constraints, integer
+ * variables, binary variables, and unrestricted variables.
+ *
+ * @param {string|string[]} input - LP format text (string or array of lines).
+ * @returns {object} JSON model definition compatible with solver.Solve().
+ */
 function to_JSON(input) {
     var rxo = {
             /* jshint ignore:start */
@@ -202,14 +211,16 @@ function to_JSON(input) {
     return model;
 }
 
-/*************************************************************
- * Method: from_JSON
- * Scope: Public:
- * Agruments: model: The model we want solver to operate on
- * Purpose: Convert a friendly JSON model into a model for a
- *          real solving library...in this case
- *          lp_solver
- **************************************************************/
+/**
+ * Convert a JSON model definition to LP format text.
+ *
+ * Generates the objective line, constraint lines (with proper <=, >=, = operators),
+ * integer variable declarations, and unrestricted variable declarations.
+ *
+ * @param {object} model - The JSON model definition.
+ * @returns {string} LP format text suitable for lp_solve.
+ * @throws {Error} If model is null/undefined.
+ */
 function from_JSON(model) {
     // Make sure we at least have a model
     if (!model) {
@@ -287,10 +298,17 @@ function from_JSON(model) {
     return output;
 }
 
+/**
+ * Auto-detect conversion direction based on input type.
+ *
+ * If the input has a `length` property (string or array), it's treated as
+ * LP format text and converted to JSON. Otherwise, it's treated as a JSON
+ * model and converted to LP format text.
+ *
+ * @param {object|string|string[]} model - LP format input or JSON model.
+ * @returns {object|string} JSON model or LP format text.
+ */
 module.exports = function (model) {
-    // If the user is giving us an array
-    // or a string, convert it to a JSON Model
-    // otherwise, spit it out as a string
     if (model.length) {
         return to_JSON(model);
     } else {

--- a/src/external/main.ts
+++ b/src/external/main.ts
@@ -11,11 +11,18 @@
 import lpsolve from "./lpsolve/main";
 import type { Model as ModelDefinition } from "../types/solver";
 
+/**
+ * Interface for an external solver integration module.
+ * Each module provides at least a `solve` method for delegating to an external process.
+ */
 export interface ExternalSolverModule {
+    /** Convert a JSON model to the external solver's input format. */
     reformat?: (model: ModelDefinition) => unknown;
+    /** Solve the model using the external solver process. */
     solve: (model: ModelDefinition) => Promise<unknown>;
 }
 
+/** Registry of available external solver modules keyed by solver name. */
 export type ExternalSolvers = Record<string, ExternalSolverModule>;
 
 const lpsolveSolver: ExternalSolverModule = lpsolve;

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,25 +30,42 @@ type ValidationFn = (model: ModelDefinition) => ModelDefinition;
 
 /**
  * Main solver class providing the public API for solving optimization problems.
+ *
+ * Typically used as a singleton (exported as `solver` from this module).
+ * Orchestrates model parsing, validation, simplex/B&C solving, and
+ * multi-objective optimization.
+ *
+ * @example
+ * ```ts
+ * import solver from "javascript-lp-solver";
+ * const result = solver.Solve({ optimize: "profit", opType: "max", ... });
+ * ```
  */
 class Solver {
-    // Expose constructors for programmatic model building
+    /** Model class constructor for programmatic model building. */
     Model = Model;
+    /** Tableau class constructor (advanced: for direct tableau manipulation). */
     Tableau = Tableau;
+    /** Constraint class constructor. */
     Constraint = expressions.Constraint;
+    /** Variable class constructor. */
     Variable = expressions.Variable;
+    /** Numeral class constructor. */
     Numeral = expressions.Numeral;
+    /** Term class constructor. */
     Term = expressions.Term;
 
-    // External solver integrations
+    /** Registry of external solver integrations (e.g., lp_solve). */
     External = External;
+    /** LP format conversion utility for external solvers. */
     ReformatLP = ReformatLP;
 
-    // Branch-and-cut service (default implementation)
+    /** Default branch-and-cut service instance. */
     branchAndCutService = createBranchAndCutService();
+    /** Convenience method to run branch-and-cut on a tableau. */
     branchAndCut = (tableau: Tableau): void => this.branchAndCutService.branchAndCut(tableau);
 
-    // Reference to the last solved model (useful for debugging)
+    /** Reference to the most recently solved Model instance (useful for post-solve inspection). */
     lastSolvedModel: Model | null = null;
 
     /**

--- a/src/model.ts
+++ b/src/model.ts
@@ -21,30 +21,78 @@ import { presolve, type PresolveResult } from "./tableau/presolve";
 
 type ConstraintDefinition = ConstraintBound | (ConstraintBound & { equal?: number });
 
+/**
+ * High-level representation of an optimization problem.
+ *
+ * Provides a programmatic API for building LP/MIP problems:
+ * - Add variables with costs, integer constraints, and priorities
+ * - Define constraints (<=, >=, =) with coefficients
+ * - Load problems from JSON model definitions
+ * - Dynamically modify models after initialization
+ *
+ * The Model converts high-level definitions into the internal Tableau
+ * representation used by the simplex algorithm.
+ *
+ * @example
+ * ```ts
+ * const model = new Model();
+ * const x = model.addVariable(3, "x");
+ * const y = model.addVariable(5, "y");
+ * model.smallerThan(10).addTerm(1, x).addTerm(2, y);
+ * const solution = model.solve();
+ * ```
+ */
 class Model {
+    /** The underlying simplex tableau. */
     tableau: Tableau;
+    /** Optional model name for identification. */
     name?: string;
+    /** All decision variables in insertion order. */
     variables: Variable[];
+    /** Subset of variables with integrality constraints. */
     integerVariables: IntegerVariable[];
+    /** Set of variable indices that may take negative values. */
     unrestrictedVariables: Record<number, boolean>;
+    /** All constraints in insertion order. */
     constraints: Constraint[];
+    /** Current number of constraints. */
     nConstraints: number;
+    /** Current number of variables. */
     nVariables: number;
+    /** True for minimization, false for maximization. */
     isMinimization: boolean;
+    /** Whether the tableau has been initialized from this model. */
     tableauInitialized: boolean;
+    /** Counter for generating unique relaxation variable IDs. */
     relaxationIndex: number;
+    /** Whether MIR cuts are enabled for branch-and-cut. */
     useMIRCuts: boolean;
+    /** Whether to detect and abort on simplex pivot cycles. */
     checkForCycles: boolean;
+    /** Diagnostic messages collected during solving. */
     messages: unknown[];
+    /** Optimality tolerance for early termination in B&C. */
     tolerance?: number;
+    /** Maximum solve time in milliseconds. */
     timeout?: number;
+    /** Whether to store all integer-feasible solutions found during B&C. */
     keep_solutions?: boolean;
+    /** All integer-feasible solutions found (if keep_solutions is true). */
     solutions?: TableauSolutionSet[];
+    /** Pool of recycled variable/constraint indices. */
     availableIndexes: number[];
+    /** Next fresh index to allocate. */
     lastElementIndex: number;
+    /** Whether to apply preprocessing reductions before solving. */
     usePresolve: boolean;
+    /** Cached presolve results (null if not yet applied). */
     presolveResult: PresolveResult | null;
 
+    /**
+     * @param precision - Numerical tolerance for the tableau (default: 1e-8).
+     * @param name - Optional model name.
+     * @param branchAndCutService - Custom B&C strategy for MIP solving.
+     */
     constructor(precision?: number, name?: string, branchAndCutService?: BranchAndCutService) {
         this.tableau = new Tableau(precision, branchAndCutService);
 
@@ -81,16 +129,19 @@ class Model {
         this.presolveResult = null;
     }
 
+    /** Set the optimization direction to minimization. */
     minimize(): this {
         this.isMinimization = true;
         return this;
     }
 
+    /** Set the optimization direction to maximization. */
     maximize(): this {
         this.isMinimization = false;
         return this;
     }
 
+    /** Allocate a new element index, reusing from pool if available. */
     _getNewElementIndex(): number {
         if (this.availableIndexes.length > 0) {
             return this.availableIndexes.pop() as number;
@@ -101,6 +152,7 @@ class Model {
         return index;
     }
 
+    /** Register a constraint with the model and propagate to tableau if initialized. */
     _addConstraint(constraint: Constraint): void {
         const slackVariable = constraint.slack;
         this.tableau.variablesPerIndex[slackVariable.index] = slackVariable;
@@ -111,18 +163,33 @@ class Model {
         }
     }
 
+    /**
+     * Create a <= (upper bound) constraint.
+     * @param rhs - The upper bound value.
+     * @returns The new constraint (add terms via .addTerm()).
+     */
     smallerThan(rhs: number): Constraint {
         const constraint = new Constraint(rhs, true, this.tableau.getNewElementIndex(), this);
         this._addConstraint(constraint);
         return constraint;
     }
 
+    /**
+     * Create a >= (lower bound) constraint.
+     * @param rhs - The lower bound value.
+     * @returns The new constraint (add terms via .addTerm()).
+     */
     greaterThan(rhs: number): Constraint {
         const constraint = new Constraint(rhs, false, this.tableau.getNewElementIndex(), this);
         this._addConstraint(constraint);
         return constraint;
     }
 
+    /**
+     * Create an equality constraint (implemented as paired upper + lower bounds).
+     * @param rhs - The equality value.
+     * @returns An Equality wrapping both bounds (add terms via .addTerm()).
+     */
     equal(rhs: number): Equality {
         const constraintUpper = new Constraint(rhs, true, this.tableau.getNewElementIndex(), this);
         this._addConstraint(constraintUpper);
@@ -133,6 +200,16 @@ class Model {
         return new Equality(constraintUpper, constraintLower);
     }
 
+    /**
+     * Add a decision variable to the model.
+     *
+     * @param cost - Objective function coefficient (default: 0).
+     * @param id - Unique identifier (default: auto-generated).
+     * @param isInteger - If true, the variable is restricted to integer values.
+     * @param isUnrestricted - If true, the variable may be negative.
+     * @param priority - Priority level for hierarchical optimization.
+     * @returns The newly created Variable instance.
+     */
     addVariable(
         cost?: number | null,
         id?: string | null,
@@ -195,6 +272,7 @@ class Model {
         return variable;
     }
 
+    /** Remove a single constraint from the model and propagate to tableau. */
     _removeConstraint(constraint: Constraint): void {
         const idx = this.constraints.indexOf(constraint);
         if (idx === -1) {
@@ -215,9 +293,13 @@ class Model {
         }
     }
 
-    //-------------------------------------------------------------------
-    // For dynamic model modification
-    //-------------------------------------------------------------------
+    /**
+     * Remove a constraint or equality from the model.
+     * For equalities, removes both the upper and lower bound constraints.
+     *
+     * @param constraint - The Constraint or Equality to remove.
+     * @returns This model for chaining.
+     */
     removeConstraint(constraint: Constraint | Equality): this {
         if ((constraint as Equality).isEquality) {
             const equalityConstraint = constraint as Equality;
@@ -230,6 +312,11 @@ class Model {
         return this;
     }
 
+    /**
+     * Remove a variable from the model.
+     * @param variable - The variable to remove.
+     * @returns This model for chaining, or void if variable not found.
+     */
     removeVariable(variable: Variable): this | void {
         const idx = this.variables.indexOf(variable);
         if (idx === -1) {
@@ -246,6 +333,11 @@ class Model {
         return this;
     }
 
+    /**
+     * Update a constraint's RHS in the live tableau.
+     * @param constraint - The constraint to update.
+     * @param difference - Amount to subtract from the current RHS.
+     */
     updateRightHandSide(constraint: Constraint, difference: number): this {
         if (this.tableauInitialized === true) {
             this.tableau.updateRightHandSide(constraint, difference);
@@ -253,6 +345,12 @@ class Model {
         return this;
     }
 
+    /**
+     * Update a variable's coefficient in a constraint in the live tableau.
+     * @param constraint - The constraint being modified.
+     * @param variable - The variable whose coefficient is changing.
+     * @param difference - Amount to add to the current coefficient.
+     */
     updateConstraintCoefficient(
         constraint: Constraint,
         variable: Variable,
@@ -264,6 +362,11 @@ class Model {
         return this;
     }
 
+    /**
+     * Change a variable's objective coefficient.
+     * @param cost - New objective coefficient value.
+     * @param variable - The variable to update.
+     */
     setCost(cost: number, variable: Variable): this {
         let difference = cost - variable.cost;
         if (this.isMinimization === false) {
@@ -275,8 +378,16 @@ class Model {
         return this;
     }
 
-    //-------------------------------------------------------------------
-    //-------------------------------------------------------------------
+    /**
+     * Load a problem from the JSON model definition format.
+     *
+     * Parses constraints, variables, integer/binary flags, and solver options
+     * from the JSON structure. Supports equality constraints (via paired bounds),
+     * soft constraints (weight/priority), and binary variable upper bounds.
+     *
+     * @param jsonModel - The JSON model definition.
+     * @returns This model for chaining.
+     */
     loadJson(jsonModel: JsonModel): this {
         this.isMinimization = jsonModel.opType !== "max";
 
@@ -433,12 +544,19 @@ class Model {
         return this;
     }
 
-    //-------------------------------------------------------------------
-    //-------------------------------------------------------------------
+    /** @returns The number of integer-constrained variables in this model. */
     getNumberOfIntegerVariables(): number {
         return this.integerVariables.length;
     }
 
+    /**
+     * Solve the optimization problem.
+     *
+     * Applies presolve reductions (if enabled), initializes the tableau,
+     * and runs simplex (for LP) or branch-and-cut (for MIP).
+     *
+     * @returns The solution with objective value and variable assignments.
+     */
     solve(): TableauSolution {
         // Apply presolve to reduce problem size
         if (this.usePresolve && this.presolveResult === null) {
@@ -481,26 +599,38 @@ class Model {
         // A more aggressive presolve would rebuild the model without fixed variables.
     }
 
+    /** @returns Whether the last solve found a feasible solution. */
     isFeasible(): boolean {
         return this.tableau.feasible;
     }
 
+    /** Snapshot the current tableau state for later restoration. */
     save(): void {
         this.tableau.save();
     }
 
+    /** Restore the tableau to the previously saved state. */
     restore(): void {
         this.tableau.restore();
     }
 
+    /**
+     * Enable or disable Mixed Integer Rounding cuts.
+     * @param useMIRCuts - Whether to apply MIR cuts during branch-and-cut.
+     */
     activateMIRCuts(useMIRCuts: boolean): void {
         this.useMIRCuts = useMIRCuts;
     }
 
+    /**
+     * Enable or disable cycle detection in the simplex algorithm.
+     * @param debugCheckForCycles - Whether to check for pivot cycles.
+     */
     debug(debugCheckForCycles: boolean): void {
         this.checkForCycles = debugCheckForCycles;
     }
 
+    /** Print the tableau to console for debugging. */
     log(message: unknown): Tableau {
         return this.tableau.log(message);
     }

--- a/src/polyopt.ts
+++ b/src/polyopt.ts
@@ -11,21 +11,29 @@
  * the min/max ranges for each objective.
  */
 import type { Model as ModelDefinition, ObjectiveDirection, SolveResult } from "./types/solver";
+/** Minimal solver interface required by Polyopt (allows decoupling from Solver class). */
 interface SolverLike {
     Solve(model: ModelDefinition, precision?: number, full?: boolean, validate?: boolean): unknown;
 }
 
-// Multi-objective solutions are still shaped like regular solve results but may
-// include additional numeric attributes for the auxiliary objectives.
+/** Extended solve result with numeric attributes for all objectives. */
 type PolyoptSolution = SolveResult & Record<string, number>;
 
+/** Map of objective attribute names to their optimization directions. */
 type ObjectiveMap = Record<string, ObjectiveDirection>;
 
+/** A Pareto-optimal point: variable values achieving an extreme objective combination. */
 type Vertex = Record<string, number>;
 
+/**
+ * Result of multi-objective optimization.
+ */
 interface PolyoptResult {
+    /** The compromise solution at the midpoint of Pareto-optimal vertices. */
     midpoint: PolyoptSolution;
+    /** Individual Pareto-optimal solutions (one per objective optimized independently). */
     vertices: Vertex[];
+    /** Min/max ranges for each objective attribute across all vertices. */
     ranges: Record<string, { min: number; max: number }>;
 }
 
@@ -143,9 +151,17 @@ function computeRanges(vertices: Vertex[]): Record<string, { min: number; max: n
 }
 
 /**
- * Solve a model with multiple objective functions by optimizing each objective
- * independently, collecting the resulting Pareto vertices, and solving a
- * derived model that targets the midpoint across all objectives.
+ * Solve a model with multiple objective functions using compromise programming.
+ *
+ * Algorithm:
+ * 1. Optimize each objective independently to find Pareto-optimal vertices.
+ * 2. Average the vertex values to compute a target midpoint.
+ * 3. Solve a derived model with equality constraints at the midpoint.
+ *
+ * @param solver - A solver instance (or anything with a compatible `Solve` method).
+ * @param model - The model with `optimize` as a `Record<string, ObjectiveDirection>`.
+ * @returns Midpoint solution, all Pareto vertices, and min/max ranges per objective.
+ * @throws If `optimize` has no keys or solver returns a non-object result.
  */
 export default function Polyopt(solver: SolverLike, model: ModelDefinition): PolyoptResult {
     const workingModel = cloneModel(model);

--- a/src/tableau/backup.ts
+++ b/src/tableau/backup.ts
@@ -10,6 +10,15 @@
  */
 import type Tableau from "./tableau";
 
+/**
+ * Create a deep copy of this tableau's state.
+ *
+ * Copies all mutable state (matrix, index arrays, optional objectives) while
+ * sharing immutable references (variables, model). The matrix is copied using
+ * the Float64Array constructor for maximum speed.
+ *
+ * @returns A new Tableau instance with identical state.
+ */
 export function copy(this: Tableau): Tableau {
     const copy = new (this.constructor as typeof Tableau)(this.precision, this.branchAndCutService);
 
@@ -46,10 +55,23 @@ export function copy(this: Tableau): Tableau {
     return copy;
 }
 
+/**
+ * Snapshot the current tableau state for later restoration.
+ * Used before branch-and-cut to establish a root state that branches can revert to.
+ */
 export function save(this: Tableau): void {
     this.savedState = this.copy();
 }
 
+/**
+ * Restore the tableau to the previously saved state.
+ *
+ * Copies all mutable arrays from the saved snapshot back into the current tableau.
+ * Uses `Float64Array.set()` for efficient matrix restoration and explicit loops
+ * for index arrays to avoid allocation.
+ *
+ * No-op if no state has been saved.
+ */
 export function restore(this: Tableau): void {
     if (this.savedState === null) {
         return;

--- a/src/tableau/branch-and-cut.ts
+++ b/src/tableau/branch-and-cut.ts
@@ -16,19 +16,35 @@ import type Tableau from "./tableau";
 import type { Branch, BranchCut } from "./types";
 import { BranchMinHeap } from "./min-heap";
 
+/**
+ * Interface for branch-and-cut solver services.
+ * Implementations provide the strategy for exploring the B&B tree.
+ */
 export interface BranchAndCutService {
+    /** Apply bound cuts and re-solve the LP relaxation. */
     applyCuts(tableau: Tableau, branchingCuts: BranchCut[]): void;
+    /** Run the full branch-and-cut algorithm to find an integer-optimal solution. */
     branchAndCut(tableau: Tableau): void;
 }
 
+/** Helper to create a BranchCut object. */
 function createCut(type: BranchCut["type"], varIndex: number, value: number): BranchCut {
     return { type, varIndex, value };
 }
 
+/** Helper to create a Branch node. */
 function createBranch(relaxedEvaluation: number, cuts: BranchCut[]): Branch {
     return { relaxedEvaluation, cuts };
 }
 
+/**
+ * Create the default (basic) branch-and-cut service.
+ *
+ * Uses best-first node selection via a min-heap, most-fractional branching,
+ * and optional MIR cuts. Suitable for small-to-medium MIP instances.
+ *
+ * @returns A BranchAndCutService with applyCuts and branchAndCut methods.
+ */
 export function createBranchAndCutService(): BranchAndCutService {
     const applyCuts = (tableau: Tableau, branchingCuts: BranchCut[]): void => {
         tableau.restore();

--- a/src/tableau/cutting-strategies.ts
+++ b/src/tableau/cutting-strategies.ts
@@ -13,6 +13,15 @@ import type Tableau from "./tableau";
 import { SlackVariable } from "../expressions";
 import type { BranchCut } from "./types";
 
+/**
+ * Add bound constraints (cuts) to the tableau for branch-and-bound.
+ *
+ * Each cut adds a new row enforcing a variable bound (x >= value or x <= value).
+ * The matrix is grown with 50% over-allocation to reduce reallocation frequency.
+ * New slack variables are created for each added row.
+ *
+ * @param cutConstraints - Array of bound constraints to add.
+ */
 export function addCutConstraints(this: Tableau, cutConstraints: BranchCut[]): void {
     const nCutConstraints = cutConstraints.length;
     const height = this.height;
@@ -80,6 +89,16 @@ export function addCutConstraints(this: Tableau, cutConstraints: BranchCut[]): v
     }
 }
 
+/**
+ * Add a lower-bound Mixed Integer Rounding (MIR) cut from the given row.
+ *
+ * Generates a Gomory-style cut that is valid for integer solutions but
+ * removes the current fractional LP relaxation point. The cut coefficients
+ * are derived from the fractional parts of the tableau row.
+ *
+ * @param rowIndex - Row of the fractional integer variable to cut on.
+ * @returns True if a cut was successfully added, false if the row is unsuitable.
+ */
 export function addLowerBoundMIRCut(this: Tableau, rowIndex: number): boolean {
     if (rowIndex === this.costRowIndex) {
         return false;
@@ -151,6 +170,15 @@ export function addLowerBoundMIRCut(this: Tableau, rowIndex: number): boolean {
     return true;
 }
 
+/**
+ * Add an upper-bound Mixed Integer Rounding (MIR) cut from the given row.
+ *
+ * Similar to addLowerBoundMIRCut but derives coefficients for the complementary
+ * direction. Effective when the fractional variable is closer to its ceiling.
+ *
+ * @param rowIndex - Row of the fractional integer variable to cut on.
+ * @returns True if a cut was successfully added, false if the row is unsuitable.
+ */
 export function addUpperBoundMIRCut(this: Tableau, rowIndex: number): boolean {
     if (rowIndex === this.costRowIndex) {
         return false;
@@ -220,9 +248,13 @@ export function addUpperBoundMIRCut(this: Tableau, rowIndex: number): boolean {
     return true;
 }
 
+/**
+ * Apply MIR cuts to all rows with fractional integer basic variables.
+ *
+ * Iterates through constraint rows, adding lower-bound MIR cuts where
+ * applicable. Limited to 10 cuts per call to avoid excessive tableau growth.
+ */
 export function applyMIRCuts(this: Tableau): void {
-    // Apply MIR (Mixed Integer Rounding) cuts to all rows with fractional integer variables
-    // This tightens the LP relaxation and can help prune the branch-and-bound tree
     const height = this.height;
     let cutsAdded = 0;
     const maxCuts = 10; // Limit cuts per iteration to avoid excessive growth

--- a/src/tableau/dynamic-modification.ts
+++ b/src/tableau/dynamic-modification.ts
@@ -52,7 +52,7 @@ export function takeOutOfBase(this: Tableau, varIndex: number): number {
         const r = this.rowByVarIndex[varIndex];
         const pivotRowOffset = r * width;
 
-        for (let c1 = 1; c1 < this.height; c1 += 1) {
+        for (let c1 = 1; c1 < this.width; c1 += 1) {
             const coefficient = this.matrix[pivotRowOffset + c1];
             if (coefficient < -this.precision || this.precision < coefficient) {
                 c = c1;

--- a/src/tableau/dynamic-modification.ts
+++ b/src/tableau/dynamic-modification.ts
@@ -13,6 +13,12 @@
 import type Tableau from "./tableau";
 import type { Constraint, Variable } from "../expressions";
 
+/**
+ * Ensure a variable is in the basis (basic). If non-basic, pivot it in.
+ *
+ * @param varIndex - Internal index of the variable to make basic.
+ * @returns Row index where the variable is now basic.
+ */
 export function putInBase(this: Tableau, varIndex: number): number {
     const width = this.width;
     let r = this.rowByVarIndex[varIndex];
@@ -33,6 +39,12 @@ export function putInBase(this: Tableau, varIndex: number): number {
     return r;
 }
 
+/**
+ * Ensure a variable is non-basic. If currently basic, pivot it out.
+ *
+ * @param varIndex - Internal index of the variable to make non-basic.
+ * @returns Column index where the variable is now non-basic.
+ */
 export function takeOutOfBase(this: Tableau, varIndex: number): number {
     const width = this.width;
     let c = this.colByVarIndex[varIndex];
@@ -54,6 +66,10 @@ export function takeOutOfBase(this: Tableau, varIndex: number): number {
     return c;
 }
 
+/**
+ * Read current variable values from the tableau matrix into Variable.value.
+ * Non-basic variables get value 0; basic variables get their RHS value (rounded).
+ */
 export function updateVariableValues(this: Tableau): void {
     const width = this.width;
     const matrix = this.matrix;
@@ -75,6 +91,15 @@ export function updateVariableValues(this: Tableau): void {
     }
 }
 
+/**
+ * Update a constraint's RHS value in the current tableau.
+ *
+ * If the constraint's slack is basic, directly adjusts the RHS cell.
+ * If non-basic, propagates the change through all rows using the slack column.
+ *
+ * @param constraint - The constraint to update.
+ * @param difference - Amount to subtract from the current RHS.
+ */
 export function updateRightHandSide(
     this: Tableau,
     constraint: Constraint,
@@ -105,6 +130,17 @@ export function updateRightHandSide(
     }
 }
 
+/**
+ * Update a variable's coefficient in a constraint within the active tableau.
+ *
+ * Ensures the constraint is basic (via putInBase) then applies the coefficient
+ * change. Handles both basic and non-basic target variables.
+ *
+ * @param constraint - The constraint being modified.
+ * @param variable - The variable whose coefficient is changing.
+ * @param difference - Amount to add to the current coefficient.
+ * @throws If constraint.index equals variable.index.
+ */
 export function updateConstraintCoefficient(
     this: Tableau,
     constraint: Constraint,
@@ -134,6 +170,15 @@ export function updateConstraintCoefficient(
     }
 }
 
+/**
+ * Update a variable's objective coefficient in the active tableau.
+ *
+ * If the variable is basic, propagates the cost change through the cost row
+ * (or optional objective's reduced costs). If non-basic, directly updates its column.
+ *
+ * @param variable - The variable whose cost is changing.
+ * @param difference - Amount to add to the current reduced cost.
+ */
 export function updateCost(this: Tableau, variable: Variable, difference: number): void {
     const width = this.width;
     const matrix = this.matrix;
@@ -159,6 +204,15 @@ export function updateCost(this: Tableau, variable: Variable, difference: number
     }
 }
 
+/**
+ * Add a new constraint row to the active tableau.
+ *
+ * Appends a new row with the constraint's terms expressed in the current basis.
+ * Grows the matrix capacity with exponential growth strategy if needed.
+ * The constraint's slack variable becomes the basic variable in the new row.
+ *
+ * @param constraint - The constraint to add (with terms already populated).
+ */
 export function addConstraint(this: Tableau, constraint: Constraint): void {
     const sign = constraint.isUpperBound ? 1 : -1;
     const lastRow = this.height;
@@ -216,6 +270,14 @@ export function addConstraint(this: Tableau, constraint: Constraint): void {
     this.height += 1;
 }
 
+/**
+ * Remove a constraint from the active tableau.
+ *
+ * Pivots the constraint's slack into the basis, swaps the row with the last row,
+ * and decrements the height. The slack variable's index is returned to the pool.
+ *
+ * @param constraint - The constraint to remove.
+ */
 export function removeConstraint(this: Tableau, constraint: Constraint): void {
     const slackIndex = constraint.index;
     const lastRow = this.height - 1;
@@ -244,6 +306,14 @@ export function removeConstraint(this: Tableau, constraint: Constraint): void {
     this.height -= 1;
 }
 
+/**
+ * Add a new variable (column) to the active tableau.
+ *
+ * Requires reallocating the matrix since the stride (width) changes.
+ * Sets the variable's reduced cost in the appropriate objective row.
+ *
+ * @param variable - The variable to add (cost and priority must be set).
+ */
 export function addVariable(this: Tableau, variable: Variable): void {
     const _lastRow = this.height - 1;
     const oldWidth = this.width;
@@ -292,6 +362,14 @@ export function addVariable(this: Tableau, variable: Variable): void {
     this.varIndexByCol[lastColumn] = variable.index;
 }
 
+/**
+ * Remove a variable (column) from the active tableau.
+ *
+ * Pivots the variable out of the basis if basic, then overwrites its column
+ * with the last column and decrements width. The variable index is recycled.
+ *
+ * @param variable - The variable to remove.
+ */
 export function removeVariable(this: Tableau, variable: Variable): void {
     const varIndex = variable.index;
     const width = this.width;

--- a/src/tableau/enhanced-branch-and-cut.ts
+++ b/src/tableau/enhanced-branch-and-cut.ts
@@ -14,26 +14,39 @@ import type Tableau from "./tableau";
 import type { Branch, BranchCut } from "./types";
 import { BranchMinHeap } from "./min-heap";
 
+/**
+ * Interface for the enhanced branch-and-cut service.
+ */
 export interface EnhancedBranchAndCutService {
+    /** Apply bound cuts and re-solve the LP relaxation. */
     applyCuts(tableau: Tableau, branchingCuts: BranchCut[]): void;
+    /** Run enhanced branch-and-cut with configurable strategies. */
     branchAndCut(tableau: Tableau): void;
 }
 
+/**
+ * Configuration for the enhanced branch-and-cut solver.
+ */
 export interface BranchAndCutOptions {
-    // Node selection: 'best-first' | 'depth-first' | 'hybrid'
+    /** Node selection strategy for tree traversal. "hybrid" starts depth-first then switches to best-first. */
     nodeSelection?: "best-first" | "depth-first" | "hybrid";
-    // Branching: 'most-fractional' | 'pseudocost' | 'strong'
+    /** Variable selection strategy for branching decisions. */
     branching?: "most-fractional" | "pseudocost" | "strong";
-    // Enable diving heuristic to find feasible solutions faster
+    /** Reserved for future diving heuristic implementation. */
     useDiving?: boolean;
-    // Maximum strong branching candidates
+    /** Maximum number of candidates to evaluate for strong branching. */
     strongBranchingCandidates?: number;
 }
 
+/** Accumulated pseudocost data for a single variable's branching history. */
 interface PseudoCostData {
+    /** Sum of normalized improvements from branching up on this variable. */
     upSum: number;
+    /** Number of times this variable was branched up. */
     upCount: number;
+    /** Sum of normalized improvements from branching down on this variable. */
     downSum: number;
+    /** Number of times this variable was branched down. */
     downCount: number;
 }
 
@@ -62,10 +75,16 @@ function createBranch(
 }
 
 /**
- * Enhanced branch-and-cut with:
- * - Pseudocost branching
- * - Hybrid node selection (depth-first early, best-first later)
- * - Diving heuristic for quick feasible solutions
+ * Create an enhanced branch-and-cut service with configurable strategies.
+ *
+ * Key improvements over the basic service:
+ * - **Pseudocost branching**: Learns from branching history to select better variables.
+ * - **Hybrid node selection**: Starts depth-first (fast feasible solutions), then
+ *   switches to best-first (optimal convergence) after finding the first solution.
+ * - **Strong branching**: Evaluates multiple candidates by estimating LP improvements.
+ *
+ * @param options - Configuration for node/variable selection strategies.
+ * @returns An EnhancedBranchAndCutService instance.
  */
 export function createEnhancedBranchAndCutService(
     options: BranchAndCutOptions = {}

--- a/src/tableau/incremental-branch-and-cut.ts
+++ b/src/tableau/incremental-branch-and-cut.ts
@@ -14,15 +14,26 @@ import type Tableau from "./tableau";
 import type { Branch, BranchCut } from "./types";
 import { BranchMinHeap } from "./min-heap";
 
+/**
+ * Interface for the incremental branch-and-cut service.
+ */
 export interface IncrementalBranchAndCutService {
+    /** Apply bound cuts and re-solve the LP relaxation. */
     applyCuts(tableau: Tableau, branchingCuts: BranchCut[]): void;
+    /** Run incremental branch-and-cut with checkpoint-based state management. */
     branchAndCut(tableau: Tableau): void;
 }
 
+/**
+ * Configuration for the incremental branch-and-cut solver.
+ */
 export interface IncrementalBranchAndCutOptions {
+    /** Node selection strategy for tree traversal. */
     nodeSelection?: "best-first" | "depth-first" | "hybrid";
+    /** Variable selection strategy for branching decisions. */
     branching?: "most-fractional" | "pseudocost" | "strong";
-    maxCheckpoints?: number; // Limit memory usage
+    /** Maximum number of checkpoints to store (limits memory usage). */
+    maxCheckpoints?: number;
 }
 
 /**
@@ -52,6 +63,10 @@ interface IncrementalBranch extends Branch {
     newCut?: BranchCut; // The single cut added from parent
 }
 
+/**
+ * Capture the current tableau state as a lightweight checkpoint.
+ * All arrays are copied by value so the checkpoint is independent of future mutations.
+ */
 function createCheckpoint(tableau: Tableau): StateCheckpoint {
     return {
         matrix: new Float64Array(tableau.matrix),
@@ -69,6 +84,10 @@ function createCheckpoint(tableau: Tableau): StateCheckpoint {
     };
 }
 
+/**
+ * Restore a tableau's state from a checkpoint.
+ * Reuses existing arrays where possible to avoid allocation.
+ */
 function restoreCheckpoint(tableau: Tableau, checkpoint: StateCheckpoint): void {
     // Only copy if sizes match, otherwise need full restore
     if (tableau.matrix.length >= checkpoint.matrix.length) {
@@ -127,6 +146,19 @@ interface PseudoCostData {
     downCount: number;
 }
 
+/**
+ * Create an incremental branch-and-cut service with checkpoint-based restoration.
+ *
+ * Key optimization: instead of always restoring to root and reapplying all cuts,
+ * child nodes store a parent checkpoint and apply only their new cut. This reduces
+ * cut application cost from O(depth) to O(1) per node in depth-first traversal.
+ *
+ * **Memory trade-off**: Stores one checkpoint per active tree path (capped by maxCheckpoints).
+ * Falls back to full-restore when the checkpoint limit is exceeded.
+ *
+ * @param options - Configuration for strategies and checkpoint limits.
+ * @returns An IncrementalBranchAndCutService instance.
+ */
 export function createIncrementalBranchAndCutService(
     options: IncrementalBranchAndCutOptions = {}
 ): IncrementalBranchAndCutService {

--- a/src/tableau/log.ts
+++ b/src/tableau/log.ts
@@ -11,8 +11,23 @@
  */
 import type Tableau from "./tableau";
 
+/** Global flag to enable/disable debug logging. Set to true during development. */
 const DEBUG_ENABLED = false;
 
+/**
+ * Print the current tableau state to console for debugging.
+ *
+ * Outputs the complete matrix in a formatted table showing:
+ * - Variable names along the top (non-basic) and right side (basic)
+ * - Cost row (objective function reduced costs)
+ * - Constraint rows with RHS values
+ * - Optional objective reduced costs (if hierarchical optimization)
+ * - Current feasibility and evaluation
+ *
+ * @param message - Label to display above the tableau output.
+ * @param force - If true, print even when DEBUG_ENABLED is false.
+ * @returns The tableau instance for chaining.
+ */
 export function log(this: Tableau, message: unknown, force?: boolean): Tableau {
     if (!DEBUG_ENABLED && !force) {
         return this;

--- a/src/tableau/min-heap.ts
+++ b/src/tableau/min-heap.ts
@@ -11,18 +11,37 @@
  */
 import type { Branch } from "./types";
 
+/** Internal entry pairing a branch with its insertion sequence number for LIFO tie-breaking. */
 interface HeapEntry {
     branch: Branch;
     seq: number;
 }
+
+/**
+ * Binary min-heap for branch-and-bound node selection.
+ *
+ * Orders branches by relaxed objective value (lowest first), with LIFO
+ * tie-breaking so that more recently created nodes are explored first
+ * when evaluations are equal. This mimics depth-first behavior in ties.
+ *
+ * Uses a flat array for cache efficiency and an object pool to reduce
+ * garbage collection pressure during intensive B&B traversals.
+ */
 export class BranchMinHeap {
+    /** Flat array storing heap entries in tree order. */
     private heap: HeapEntry[];
+    /** Number of entries currently in the heap. */
     private size: number;
+    /** Monotonically increasing counter for LIFO tie-breaking. */
     private seqCounter: number;
-    // Object pool to reduce GC pressure
+    /** Object pool for reusing HeapEntry objects. */
     private pool: HeapEntry[];
+    /** Current number of entries in the pool. */
     private poolSize: number;
 
+    /**
+     * @param initialCapacity - Pre-allocated array size (grows automatically if exceeded).
+     */
     constructor(initialCapacity = 64) {
         this.heap = new Array(initialCapacity);
         this.size = 0;
@@ -31,6 +50,7 @@ export class BranchMinHeap {
         this.poolSize = 0;
     }
 
+    /** Allocate a HeapEntry, reusing from the pool if available. */
     private allocEntry(branch: Branch, seq: number): HeapEntry {
         if (this.poolSize > 0) {
             const entry = this.pool[--this.poolSize];
@@ -41,26 +61,33 @@ export class BranchMinHeap {
         return { branch, seq };
     }
 
+    /** Return a HeapEntry to the pool for reuse (capped at 256 entries). */
     private freeEntry(entry: HeapEntry): void {
         if (this.poolSize < 256) {
             this.pool[this.poolSize++] = entry;
         }
     }
 
+    /** Number of branches currently in the heap. */
     get length(): number {
         return this.size;
     }
 
+    /** Whether the heap contains no branches. */
     isEmpty(): boolean {
         return this.size === 0;
     }
 
+    /** Remove all entries and reset the sequence counter. */
     clear(): void {
         this.size = 0;
         this.seqCounter = 0;
     }
 
-    // Compare: returns true if a should be before b (a has higher priority)
+    /**
+     * Compare two entries for priority ordering.
+     * @returns True if `a` should be extracted before `b`.
+     */
     private isBefore(a: HeapEntry, b: HeapEntry): boolean {
         if (a.branch.relaxedEvaluation !== b.branch.relaxedEvaluation) {
             return a.branch.relaxedEvaluation < b.branch.relaxedEvaluation;
@@ -69,6 +96,10 @@ export class BranchMinHeap {
         return a.seq > b.seq;
     }
 
+    /**
+     * Insert a branch into the heap. O(log n).
+     * @param branch - The B&B node to insert.
+     */
     push(branch: Branch): void {
         const heap = this.heap;
         let idx = this.size;
@@ -94,6 +125,10 @@ export class BranchMinHeap {
         heap[idx] = entry;
     }
 
+    /**
+     * Remove and return the highest-priority branch (lowest relaxed evaluation). O(log n).
+     * @returns The most promising branch, or undefined if empty.
+     */
     pop(): Branch | undefined {
         if (this.size === 0) {
             return undefined;
@@ -138,6 +173,10 @@ export class BranchMinHeap {
         return result;
     }
 
+    /**
+     * View the highest-priority branch without removing it. O(1).
+     * @returns The most promising branch, or undefined if empty.
+     */
     peek(): Branch | undefined {
         return this.size > 0 ? this.heap[0].branch : undefined;
     }

--- a/src/tableau/mip-utils.ts
+++ b/src/tableau/mip-utils.ts
@@ -16,6 +16,10 @@ import type { VariableValue } from "./types";
 
 /**
  * Count how many integer variables currently have integral values.
+ * A value is considered integral if its distance to the nearest integer
+ * is within the tableau's precision tolerance.
+ *
+ * @returns Number of integer variables with integral current values.
  */
 export function countIntegerValues(this: Tableau): number {
     let count = 0;
@@ -37,8 +41,9 @@ export function countIntegerValues(this: Tableau): number {
 }
 
 /**
- * Check if all integer variables have integral values.
- * Returns true if the current solution is integral.
+ * Check if all integer variables have integral values within precision.
+ *
+ * @returns True if the current solution satisfies all integrality constraints.
  */
 export function isIntegral(this: Tableau): boolean {
     const width = this.width;
@@ -64,8 +69,14 @@ export function isIntegral(this: Tableau): boolean {
 }
 
 /**
- * Compute a measure of how fractional the current solution is.
- * Used for evaluating the quality of cutting planes.
+ * Compute a measure of total fractionality across all integer variables.
+ *
+ * The "volume" is the product of fractional values. Used to evaluate cutting
+ * plane effectiveness: a decreasing volume indicates the LP relaxation is
+ * tightening toward integrality.
+ *
+ * @param ignoreIntegerValues - If true, skip already-integral variables (don't return 0 early).
+ * @returns Product of fractional variable values, or 0 if all are integral.
  */
 export function computeFractionalVolume(this: Tableau, ignoreIntegerValues?: boolean): number {
     let volume = -1;
@@ -100,8 +111,13 @@ export function computeFractionalVolume(this: Tableau, ignoreIntegerValues?: boo
 // ========== Branching Variable Selection ==========
 
 /**
- * Select the integer variable with the most fractional value.
- * Standard branching strategy - picks the variable closest to 0.5 fractionality.
+ * Select the integer variable with the most fractional value for branching.
+ *
+ * This is the default branching strategy. Picks the variable whose current
+ * value is farthest from the nearest integer (closest to 0.5 fractionality),
+ * creating the most balanced branching.
+ *
+ * @returns The selected variable's index and value, or nulls if all are integral.
  */
 export function getMostFractionalVar(this: Tableau): VariableValue {
     let biggestFraction = 0;
@@ -134,8 +150,13 @@ export function getMostFractionalVar(this: Tableau): VariableValue {
 }
 
 /**
- * Select the fractional integer variable with the lowest cost coefficient.
- * Alternative branching strategy that considers objective function impact.
+ * Select the fractional integer variable with the lowest objective coefficient.
+ *
+ * Alternative branching strategy that prioritizes variables with less
+ * objective impact, potentially leading to smaller objective degradation
+ * in child nodes.
+ *
+ * @returns The selected variable's index and value, or nulls if all are integral.
  */
 export function getFractionalVarWithLowestCost(this: Tableau): VariableValue {
     let highestCost = Infinity;

--- a/src/tableau/presolve.ts
+++ b/src/tableau/presolve.ts
@@ -13,14 +13,26 @@
 import type Model from "../model";
 import type { Variable, Constraint } from "../expressions";
 
+/**
+ * Results from the presolve preprocessing phase.
+ * Contains all reductions discovered and an infeasibility flag.
+ */
 export interface PresolveResult {
+    /** Variables proven to have a unique feasible value. */
     fixedVariables: Map<Variable, number>;
+    /** Constraints proven to be redundant (always satisfied). */
     removedConstraints: Set<Constraint>;
+    /** Variables with tightened lower/upper bounds from constraint analysis. */
     tightenedBounds: Map<Variable, { lower?: number; upper?: number }>;
+    /** Set to true if preprocessing proves the problem has no feasible solution. */
     isInfeasible: boolean;
+    /** Summary statistics of reductions applied. */
     stats: {
+        /** Number of variables fixed to a constant value. */
         variablesFixed: number;
+        /** Number of constraints removed as redundant. */
         constraintsRemoved: number;
+        /** Number of variable bounds tightened. */
         boundsTightened: number;
     };
 }

--- a/src/tableau/simplex.ts
+++ b/src/tableau/simplex.ts
@@ -17,10 +17,23 @@ import type Tableau from "./tableau";
  * This version uses a Map to track where each (leaving,entering) pair occurred,
  * making duplicate detection O(1) average case.
  */
+/**
+ * Detects pivot cycles using hash-based O(1) lookups.
+ *
+ * Tracks all (leaving, entering) pairs seen during simplex pivots.
+ * When a duplicate pair is detected, verifies whether the sequence
+ * after the first occurrence repeats, confirming a cycle.
+ */
 class CycleDetector {
     private pairs: Array<[number, number]> = [];
     private positions: Map<string, number[]> = new Map();
 
+    /**
+     * Record a pivot and check for cycles.
+     * @param leaving - Variable index leaving the basis.
+     * @param entering - Variable index entering the basis.
+     * @returns [startPosition, cycleLength] if cycle detected, empty array otherwise.
+     */
     add(leaving: number, entering: number): number[] {
         const key = `${leaving}_${entering}`;
         const pos = this.pairs.length;
@@ -64,6 +77,14 @@ class CycleDetector {
     }
 }
 
+/**
+ * Run the full two-phase simplex algorithm.
+ *
+ * Phase 1 finds a basic feasible solution (or proves infeasibility).
+ * Phase 2 optimizes the objective (or proves unboundedness).
+ *
+ * @returns The tableau instance for chaining.
+ */
 export function simplex(this: Tableau): Tableau {
     this.bounded = true;
     this.phase1();
@@ -166,6 +187,15 @@ export function dualSimplex(this: Tableau): number {
     return iterations;
 }
 
+/**
+ * Phase 1: Find an initial basic feasible solution.
+ *
+ * Pivots to eliminate negative RHS values (infeasible basic variables).
+ * Uses max-quotient rule for fast convergence, with anti-cycling fallback
+ * to Bland's rule if degenerate stalling is detected.
+ *
+ * @returns Number of pivot iterations performed.
+ */
 export function phase1(this: Tableau): number {
     const debugCheckForCycles = this.model.checkForCycles;
     const cycleDetector = debugCheckForCycles ? new CycleDetector() : null;
@@ -346,6 +376,18 @@ export function phase1(this: Tableau): number {
     }
 }
 
+/**
+ * Phase 2: Optimize the objective function.
+ *
+ * Pivots to improve the objective by selecting entering variables with
+ * positive reduced costs. Uses partial pricing on large problems (batched
+ * column scanning) and falls back to Bland's rule on degenerate cycling.
+ *
+ * Handles hierarchical (multi-priority) objectives by checking optional
+ * objective reduced costs when the primary objective is at optimality.
+ *
+ * @returns Number of pivot iterations performed.
+ */
 export function phase2(this: Tableau): number {
     const debugCheckForCycles = this.model.checkForCycles;
     const cycleDetector = debugCheckForCycles ? new CycleDetector() : null;
@@ -647,10 +689,20 @@ export function phase2(this: Tableau): number {
     }
 }
 
-// Pre-allocated typed arrays for pivot optimization (better cache performance)
+// Pre-allocated typed arrays for pivot optimization (better cache locality)
 let nonZeroColumns = new Int32Array(1024);
 let pivotRowCache = new Float64Array(1024);
 
+/**
+ * Perform a single simplex pivot operation.
+ *
+ * Swaps the entering variable (non-basic, in column) with the leaving variable
+ * (basic, in row). Updates the entire matrix using cached pivot row values
+ * for better cache locality. Also updates optional objective reduced costs.
+ *
+ * @param pivotRowIndex - Row of the leaving variable.
+ * @param pivotColumnIndex - Column of the entering variable.
+ */
 export function pivot(this: Tableau, pivotRowIndex: number, pivotColumnIndex: number): void {
     const matrix = this.matrix;
     const width = this.width;
@@ -744,6 +796,13 @@ export function pivot(this: Tableau, pivotRowIndex: number, pivotColumnIndex: nu
     }
 }
 
+/**
+ * Legacy O(n^2) cycle detection by brute-force pair comparison.
+ * Superseded by CycleDetector but retained for API compatibility.
+ *
+ * @param varIndexes - Array of [leaving, entering] pairs from pivot history.
+ * @returns [startIndex, cycleLength] if cycle found, empty array otherwise.
+ */
 export function checkForCycles(this: Tableau, varIndexes: Array<[number, number]>): number[] {
     for (let e1 = 0; e1 < varIndexes.length - 1; e1++) {
         for (let e2 = e1 + 1; e2 < varIndexes.length; e2++) {

--- a/src/tableau/solution.ts
+++ b/src/tableau/solution.ts
@@ -13,14 +13,28 @@ import type { TableauSolutionSet } from "./types";
 
 /**
  * Represents a solution to a linear programming problem.
+ *
+ * Contains the feasibility status, objective value, and provides a method
+ * to extract variable values from the tableau's current state.
  */
 export class Solution {
+    /** Whether the solver found a feasible solution. */
     feasible: boolean;
+    /** Optimal objective function value (in the model's original direction). */
     evaluation: number;
+    /** Whether the problem is bounded (false = unbounded objective). */
     bounded: boolean;
+    /** Reference to the source tableau (used by generateSolutionSet). */
     _tableau: Tableau;
+    /** Cached variable-to-value mapping (populated by generateSolutionSet). */
     solutionSet: TableauSolutionSet;
 
+    /**
+     * @param tableau - The solved tableau containing variable values.
+     * @param evaluation - Objective value (already sign-corrected for min/max).
+     * @param feasible - Whether a feasible solution exists.
+     * @param bounded - Whether the objective is bounded.
+     */
     constructor(tableau: Tableau, evaluation: number, feasible: boolean, bounded: boolean) {
         this.feasible = feasible;
         this.evaluation = evaluation;
@@ -30,7 +44,12 @@ export class Solution {
     }
 
     /**
-     * Generate the solution set mapping variable IDs to their values.
+     * Extract variable values from the tableau's current state.
+     *
+     * Iterates over all basic variables, skipping slack variables, and
+     * rounds values to the tableau's precision to avoid floating-point noise.
+     *
+     * @returns A map from variable ID to its solution value.
      */
     generateSolutionSet(): TableauSolutionSet {
         const solutionSet: TableauSolutionSet = {};
@@ -62,11 +81,21 @@ export class Solution {
 
 /**
  * Represents a solution to a mixed-integer programming problem.
- * Extends Solution with branch-and-cut iteration tracking.
+ *
+ * Extends the base Solution with the number of branch-and-cut iterations
+ * performed, which is useful for performance analysis and debugging.
  */
 export class MilpSolution extends Solution {
+    /** Number of branch-and-cut iterations (nodes explored) to find this solution. */
     iter: number;
 
+    /**
+     * @param tableau - The solved tableau.
+     * @param evaluation - Objective value.
+     * @param feasible - Whether an integer-feasible solution was found.
+     * @param bounded - Whether the problem is bounded.
+     * @param branchAndCutIterations - Number of B&C nodes explored.
+     */
     constructor(
         tableau: Tableau,
         evaluation: number,

--- a/src/tableau/tableau.ts
+++ b/src/tableau/tableau.ts
@@ -24,6 +24,12 @@ import * as backupOps from "./backup";
 import * as mipOps from "./mip-utils";
 import { log as logImpl } from "./log";
 
+/**
+ * Factory for OptionalObjective instances.
+ * @param priority - Priority level (lower = higher priority).
+ * @param nColumns - Number of columns to allocate for reduced costs.
+ * @param reducedCosts - Initial reduced costs (copied if provided).
+ */
 function createOptionalObjective(
     priority: number,
     nColumns: number,
@@ -42,56 +48,103 @@ function createOptionalObjective(
     };
 }
 
+/**
+ * Core simplex tableau data structure.
+ *
+ * Stores the LP problem in matrix form (Float64Array for numerical precision)
+ * and provides methods for simplex operations, branch-and-cut, and dynamic
+ * model modification. Each row represents a basic variable; each column
+ * represents a non-basic variable. The first row is the cost (objective) row;
+ * the first column is the RHS column.
+ *
+ * This class delegates its method implementations to separate modules
+ * (simplex, cutting-strategies, backup, etc.) for maintainability.
+ */
 export default class Tableau {
+    /** The model this tableau was built from (null until setModel is called). */
     model: Model | null = null;
 
+    /** Flat row-major matrix storage. Element at (row, col) is matrix[row * width + col]. */
     matrix: Float64Array = new Float64Array(0);
+    /** Number of columns (non-basic variables + RHS column). */
     width = 0;
+    /** Number of rows (basic variables + cost row). */
     height = 0;
 
+    /** Row index of the objective function (always 0). */
     costRowIndex = 0;
+    /** Column index of the RHS values (always 0). */
     rhsColumn = 0;
 
+    /** Lookup table: internal variable index -> Variable object. */
     variablesPerIndex: Array<Variable | undefined> = [];
+    /** Set of variable indices that are unrestricted (may be negative). */
     unrestrictedVars: Record<number, boolean> = {};
 
+    /** Whether the current solution is feasible. Set to false by phase 1 if no BFS found. */
     feasible = true;
+    /** Current objective function value (negated internally for minimization). */
     evaluation = 0;
+    /** Total simplex iterations performed across all phases. */
     simplexIters = 0;
 
+    /** Maps row index -> variable index of the basic variable in that row. */
     varIndexByRow: number[] = [];
+    /** Maps column index -> variable index of the non-basic variable in that column. */
     varIndexByCol: number[] = [];
 
+    /** Maps variable index -> row index (-1 if non-basic). */
     rowByVarIndex: number[] = [];
+    /** Maps variable index -> column index (-1 if basic). */
     colByVarIndex: number[] = [];
 
+    /** Numerical precision tolerance for integrality and zero comparisons. */
     precision: number;
 
+    /** Secondary objectives sorted by priority (for hierarchical optimization). */
     optionalObjectives: OptionalObjective[] = [];
+    /** Lookup: priority level -> optional objective. */
     objectivesByPriority: Record<number, OptionalObjective> = {};
+    /** Alias for objectivesByPriority (legacy compatibility). */
     optionalObjectivePerPriority: Record<number, OptionalObjective> = {};
 
+    /** Saved tableau state for branch-and-cut restoration. */
     savedState: Tableau | null = null;
 
+    /** Pool of recycled variable/constraint indices. */
     availableIndexes: number[] = [];
+    /** Next fresh index to assign (when pool is empty). */
     lastElementIndex = 0;
 
+    /** All decision variables in column order. */
     variables: Variable[] = [];
+    /** Total number of variable/constraint indices allocated. */
     nVars = 0;
 
+    /** Whether the problem is bounded (set to false if unbounded ray detected). */
     bounded = true;
+    /** Index of the unbounded variable (if bounded is false). */
     unboundedVarIndex: number | null = null;
 
+    /** Number of B&B nodes explored in the last branchAndCut call. */
     branchAndCutIterations = 0;
+    /** Best possible objective value (LP relaxation at root). */
     bestPossibleEval = 0;
+    /** Set to true when the current solution satisfies all integrality constraints. */
     __isIntegral?: boolean;
 
-    // Partial pricing state for phase2 optimization
+    /** Starting column for partial pricing sweep in phase 2. */
     pricingBatchStart = 1;
-    pricingBatchSize = 0; // 0 means auto-compute based on problem size
+    /** Batch size for partial pricing (0 = auto-compute based on problem size). */
+    pricingBatchSize = 0;
 
+    /** The branch-and-cut strategy used for MIP solving. */
     readonly branchAndCutService: BranchAndCutService;
 
+    /**
+     * @param precision - Numerical tolerance for zero/integrality tests (default: 1e-8).
+     * @param branchAndCutService - Custom B&C strategy (default: basic best-first).
+     */
     constructor(precision = 1e-8, branchAndCutService?: BranchAndCutService) {
         this.precision = precision;
         this.branchAndCutService = branchAndCutService ?? createBranchAndCutService();
@@ -99,15 +152,18 @@ export default class Tableau {
 
     // ========== Core Simplex Operations ==========
 
+    /** Run two-phase simplex to find the optimal LP solution. */
     simplex(): this {
         simplexOps.simplex.call(this);
         return this;
     }
 
+    /** Phase 1: Find a basic feasible solution. @returns Pivot iteration count. */
     phase1(): number {
         return simplexOps.phase1.call(this);
     }
 
+    /** Phase 2: Optimize the objective. @returns Pivot iteration count. */
     phase2(): number {
         return simplexOps.phase2.call(this);
     }
@@ -121,74 +177,98 @@ export default class Tableau {
         return simplexOps.dualSimplex.call(this);
     }
 
+    /**
+     * Perform a single simplex pivot.
+     * @param pivotRowIndex - Row of the leaving variable.
+     * @param pivotColumnIndex - Column of the entering variable.
+     */
     pivot(pivotRowIndex: number, pivotColumnIndex: number): void {
         simplexOps.pivot.call(this, pivotRowIndex, pivotColumnIndex);
     }
 
+    /** Detect pivot cycles in a history of (leaving, entering) pairs. */
     checkForCycles(varIndexes: Array<[number, number]>): number[] {
         return simplexOps.checkForCycles.call(this, varIndexes);
     }
 
     // ========== Integer/MIP Properties ==========
 
+    /** Count how many integer variables currently have integral values. */
     countIntegerValues(): number {
         return mipOps.countIntegerValues.call(this);
     }
 
+    /** Check if all integer variables have integral values within precision. */
     isIntegral(): boolean {
         return mipOps.isIntegral.call(this);
     }
 
+    /**
+     * Compute sum of fractionalities of integer variables.
+     * @param ignoreIntegerValues - If true, skip variables that are already integral.
+     * @returns Total fractional volume (0 = all integral).
+     */
     computeFractionalVolume(ignoreIntegerValues?: boolean): number {
         return mipOps.computeFractionalVolume.call(this, ignoreIntegerValues);
     }
 
     // ========== Cutting Strategies ==========
 
+    /** Add bound constraints and grow the tableau as needed. */
     addCutConstraints(branchingCuts: BranchCut[]): void {
         cuttingOps.addCutConstraints.call(this, branchingCuts);
     }
 
+    /** Apply MIR cuts to all fractional integer rows. */
     applyMIRCuts(): void {
         cuttingOps.applyMIRCuts.call(this);
     }
 
+    /** Add a lower-bound MIR cut from the given row. @returns True if cut was added. */
     addLowerBoundMIRCut(rowIndex: number): boolean {
         return cuttingOps.addLowerBoundMIRCut.call(this, rowIndex);
     }
 
+    /** Add an upper-bound MIR cut from the given row. @returns True if cut was added. */
     addUpperBoundMIRCut(rowIndex: number): boolean {
         return cuttingOps.addUpperBoundMIRCut.call(this, rowIndex);
     }
 
     // ========== Branching Strategies ==========
 
+    /** Find the integer variable with the most fractional current value. */
     getMostFractionalVar(): VariableValue {
         return mipOps.getMostFractionalVar.call(this);
     }
 
+    /** Find the fractional integer variable with the lowest objective cost. */
     getFractionalVarWithLowestCost(): VariableValue {
         return mipOps.getFractionalVarWithLowestCost.call(this);
     }
 
     // ========== Dynamic Modification ==========
 
+    /** Pivot a variable into the basis. @returns Its new row index. */
     putInBase(varIndex: number): number {
         return dynamicOps.putInBase.call(this, varIndex);
     }
 
+    /** Pivot a variable out of the basis. @returns Its new column index. */
     takeOutOfBase(varIndex: number): number {
         return dynamicOps.takeOutOfBase.call(this, varIndex);
     }
 
+    /** Read variable values from the matrix into Variable.value. */
     updateVariableValues(): void {
         dynamicOps.updateVariableValues.call(this);
     }
 
+    /** Update a constraint's RHS in the active tableau. */
     updateRightHandSide(constraint: Constraint, difference: number): void {
         dynamicOps.updateRightHandSide.call(this, constraint, difference);
     }
 
+    /** Update a variable's coefficient in a constraint. */
     updateConstraintCoefficient(
         constraint: Constraint,
         variable: Variable,
@@ -197,42 +277,51 @@ export default class Tableau {
         dynamicOps.updateConstraintCoefficient.call(this, constraint, variable, difference);
     }
 
+    /** Update a variable's objective coefficient. */
     updateCost(variable: Variable, difference: number): void {
         dynamicOps.updateCost.call(this, variable, difference);
     }
 
+    /** Add a new constraint row to the tableau. */
     addConstraint(constraint: Constraint): void {
         dynamicOps.addConstraint.call(this, constraint);
     }
 
+    /** Remove a constraint row from the tableau. */
     removeConstraint(constraint: Constraint): void {
         dynamicOps.removeConstraint.call(this, constraint);
     }
 
+    /** Add a new variable column to the tableau. */
     addVariable(variable: Variable): void {
         dynamicOps.addVariable.call(this, variable);
     }
 
+    /** Remove a variable column from the tableau. */
     removeVariable(variable: Variable): void {
         dynamicOps.removeVariable.call(this, variable);
     }
 
     // ========== Backup/Restore ==========
 
+    /** Create a deep copy of this tableau's mutable state. */
     copy(): Tableau {
         return backupOps.copy.call(this);
     }
 
+    /** Snapshot the current state for later restoration. */
     save(): void {
         backupOps.save.call(this);
     }
 
+    /** Restore the tableau to its previously saved state. */
     restore(): void {
         backupOps.restore.call(this);
     }
 
     // ========== Debug ==========
 
+    /** Print the tableau matrix to console for debugging. */
     log(message: unknown): this {
         logImpl.call(this, message);
         return this;
@@ -240,16 +329,22 @@ export default class Tableau {
 
     // ========== Branch and Cut ==========
 
+    /** Apply branch cuts and re-solve the LP relaxation. */
     applyCuts(branchingCuts: BranchCut[]): void {
         this.branchAndCutService.applyCuts(this, branchingCuts);
     }
 
+    /** Run branch-and-cut to find an integer-optimal solution. */
     branchAndCut(): void {
         this.branchAndCutService.branchAndCut(this);
     }
 
     // ========== Solution ==========
 
+    /**
+     * Solve the problem: run B&C for MIP or simplex for LP, then extract the solution.
+     * @returns The complete solution object.
+     */
     solve(): TableauSolution {
         if ((this.model?.getNumberOfIntegerVariables() ?? 0) > 0) {
             this.branchAndCut();
@@ -260,6 +355,7 @@ export default class Tableau {
         return this.getSolution();
     }
 
+    /** Build a Solution or MilpSolution from the current tableau state. */
     getSolution(): TableauSolution {
         const evaluation = this.model?.isMinimization === true ? this.evaluation : -this.evaluation;
 
@@ -278,6 +374,12 @@ export default class Tableau {
 
     // ========== Initialization ==========
 
+    /**
+     * Register or update a secondary (optional) objective at the given priority.
+     * @param priority - Priority level (lower = optimized first).
+     * @param column - Column index for the reduced cost entry.
+     * @param cost - Reduced cost value for this variable in this objective.
+     */
     setOptionalObjective(priority: number, column: number, cost: number): void {
         let objectiveForPriority = this.objectivesByPriority[priority];
         if (objectiveForPriority === undefined) {
@@ -292,6 +394,15 @@ export default class Tableau {
         objectiveForPriority.reducedCosts[column] = cost;
     }
 
+    /**
+     * Allocate and initialize the tableau's matrix and index arrays.
+     * Called by setModel; should not be called directly.
+     *
+     * @param width - Number of columns (variables + 1).
+     * @param height - Number of rows (constraints + 1).
+     * @param variables - All decision variables.
+     * @param unrestrictedVars - Set of unrestricted variable indices.
+     */
     initialize(
         width: number,
         height: number,
@@ -319,6 +430,7 @@ export default class Tableau {
         this.lastElementIndex = this.nVars;
     }
 
+    /** Populate the matrix with objective coefficients and constraint data from the model. */
     _resetMatrix(): void {
         if (this.model === null) {
             throw new Error("[Tableau._resetMatrix] Model not set");
@@ -382,6 +494,12 @@ export default class Tableau {
         }
     }
 
+    /**
+     * Initialize the tableau from a Model instance.
+     * Allocates the matrix and populates it with the model's data.
+     * @param model - The optimization model to load.
+     * @returns This tableau for chaining.
+     */
     setModel(model: Model): this {
         this.model = model;
 
@@ -393,6 +511,7 @@ export default class Tableau {
         return this;
     }
 
+    /** Allocate a new variable/constraint index (reuses from pool if available). */
     getNewElementIndex(): number {
         if (this.availableIndexes.length > 0) {
             return this.availableIndexes.pop() as number;
@@ -403,6 +522,7 @@ export default class Tableau {
         return index;
     }
 
+    /** Compute the fraction of non-zero entries in the matrix (for sparsity analysis). */
     density(): number {
         let density = 0;
 
@@ -420,6 +540,7 @@ export default class Tableau {
         return density / (this.height * this.width);
     }
 
+    /** Read the objective value from the matrix, round to precision, and store in this.evaluation. */
     setEvaluation(): void {
         const roundingCoeff = Math.round(1 / this.precision);
         const evaluation = this.matrix[this.costRowIndex * this.width + this.rhsColumn];

--- a/src/tableau/types.ts
+++ b/src/tableau/types.ts
@@ -9,38 +9,75 @@
  */
 import type { Solution, MilpSolution } from "./solution";
 
+/** Direction of a variable bound constraint: "min" for lower bound (x >= value), "max" for upper bound (x <= value). */
 export type BoundType = "min" | "max";
 
+/**
+ * A bound constraint on a variable, used during branch-and-bound.
+ * Each branch in the B&B tree is defined by a set of these cuts.
+ */
 export interface BranchCut {
+    /** Whether this is a lower ("min") or upper ("max") bound. */
     type: BoundType;
+    /** Internal index of the variable being bounded. */
     varIndex: number;
+    /** The bound value (e.g., ceil(x) for "min" or floor(x) for "max"). */
     value: number;
 }
 
+/**
+ * A node in the branch-and-bound tree.
+ * Stores the LP relaxation value and all bound constraints that define this node.
+ */
 export interface Branch {
+    /** Objective value of the LP relaxation at this node (used for best-first ordering). */
     relaxedEvaluation: number;
+    /** Accumulated bound constraints from root to this node. */
     cuts: BranchCut[];
-    // For pseudo-cost tracking (optional)
+    /** Index of the variable that was branched on to create this node. */
     branchVarIndex?: number;
+    /** Which direction the branch was taken ("up" = ceil, "down" = floor). */
     branchDirection?: "up" | "down";
+    /** Fractionality of the branching variable at the parent node. */
     branchFractionality?: number;
+    /** Parent node's objective value (for pseudocost computation). */
     parentEvaluation?: number;
 }
 
+/**
+ * A secondary objective in hierarchical (priority-based) optimization.
+ * Lower-priority objectives are optimized only after higher-priority ones are satisfied.
+ */
 export interface OptionalObjective {
+    /** Priority level (lower number = higher priority, 0 = primary objective). */
     priority: number;
+    /** Reduced costs for this objective across all columns. */
     reducedCosts: number[];
+    /** Create an independent copy of this objective (for tableau backup). */
     copy(): OptionalObjective;
 }
 
+/**
+ * Result of branching variable selection: the chosen variable's index and current value.
+ * Null fields indicate no fractional variable was found (solution is integral).
+ */
 export interface VariableValue {
+    /** Internal variable index, or null if no candidate found. */
     index: number | null;
+    /** Current fractional value of the variable, or null. */
     value: number | null;
 }
 
+/** Union type for solutions from both continuous LP and mixed-integer problems. */
 export type TableauSolution = Solution | MilpSolution;
 
+/**
+ * A flat map of variable IDs to their solution values.
+ * Used as an intermediate format before constructing the final SolveResult.
+ */
 export interface TableauSolutionSet {
+    /** Variable values keyed by variable ID. */
     [variable: string]: number | undefined;
+    /** The objective function value for this solution. */
     result?: number;
 }

--- a/src/types/solver.ts
+++ b/src/types/solver.ts
@@ -9,101 +9,214 @@
  * - ConstraintBound: Constraint specification
  * - Variable, Term, Constraint: Expression types
  */
+/** Direction for single-objective optimization. */
 export type ObjectiveDirection = "max" | "min";
 
+/** Constraint relation type when specified as a string shorthand. */
 export type ConstraintRelation = "min" | "max" | "equal";
 
+/**
+ * Configuration options passed to the solver to control algorithm behavior.
+ *
+ * These can be specified at the top level of the model or nested under `options`.
+ * The `options` object takes precedence over top-level properties.
+ */
 export interface SolveOptions {
+    /** Optimality tolerance for branch-and-cut. Stops early when incumbent is within this fraction of the bound. */
     tolerance?: number;
+    /** Maximum solve time in milliseconds. The solver returns the best solution found so far when exceeded. */
     timeout?: number;
+    /** Enable Mixed Integer Rounding cuts to tighten LP relaxations during branch-and-cut. */
     useMIRCuts?: boolean;
+    /** If true, abort when a pivot cycle is detected (prevents infinite loops on degenerate problems). */
     exitOnCycles?: boolean;
+    /** If true, store all integer-feasible solutions found during branch-and-cut (not just the best). */
     keep_solutions?: boolean;
-    // Enhanced solver options
+    /** Node selection strategy for branch-and-bound tree exploration. */
     nodeSelection?: "best-first" | "depth-first" | "hybrid";
+    /** Variable selection (branching) strategy for choosing which fractional variable to branch on. */
     branching?: "most-fractional" | "pseudocost" | "strong";
+    /** Enable preprocessing reductions (variable fixing, bound tightening, redundant constraint removal). */
     presolve?: boolean;
-    // Use incremental state management for B&B (default: true)
+    /** Use incremental state management for branch-and-bound (experimental; stores checkpoints to avoid full restores). */
     useIncremental?: boolean;
 }
 
+/**
+ * Specifies bounds for a constraint in the JSON model format.
+ *
+ * A constraint can have a lower bound (`min`), upper bound (`max`), or equality (`equal`).
+ * Soft constraints can specify `weight` and `priority` for relaxation.
+ */
 export interface ConstraintBound {
+    /** Lower bound: the constraint sum must be >= this value. */
     min?: number;
+    /** Upper bound: the constraint sum must be <= this value. */
     max?: number;
+    /** Equality: the constraint sum must equal this value exactly. */
     equal?: number;
+    /** Relaxation weight for soft constraints. Higher weight = harder to violate. */
     weight?: number;
+    /** Relaxation priority level. "required" constraints cannot be violated. */
     priority?: number | "required" | "strong" | "medium" | "weak";
 }
 
+/**
+ * Maps constraint names to the variable's coefficient in each constraint.
+ * Also includes the objective attribute coefficient.
+ */
 export interface VariableCoefficients {
     [constraintName: string]: number;
 }
 
+/**
+ * JSON model definition format for specifying optimization problems.
+ *
+ * This is the primary input format for `solver.Solve()`. It defines the objective,
+ * constraints, and variables in a declarative JSON structure.
+ *
+ * @example
+ * ```ts
+ * const model: Model = {
+ *     optimize: "profit",
+ *     opType: "max",
+ *     constraints: {
+ *         wood: { max: 300 },
+ *         labor: { max: 110 }
+ *     },
+ *     variables: {
+ *         table: { wood: 30, labor: 5, profit: 1200 },
+ *         chair: { wood: 20, labor: 10, profit: 1000 }
+ *     },
+ *     ints: { table: true, chair: true }
+ * };
+ * ```
+ */
 export interface Model {
+    /** Optional model name for identification/debugging. */
     name?: string;
+    /** Attribute name to optimize, or a map of attribute names to directions for multi-objective. */
     optimize: string | Record<string, ObjectiveDirection>;
+    /** Optimization direction (ignored when `optimize` is a multi-objective map). */
     opType?: ObjectiveDirection;
+    /** Map of constraint names to their bound specifications. */
     constraints: Record<string, ConstraintBound | ConstraintRelation>;
+    /** Map of variable names to their constraint coefficients. */
     variables: Record<string, VariableCoefficients>;
+    /** Variables restricted to integer values. */
     ints?: Record<string, boolean | 0 | 1>;
+    /** Variables restricted to 0 or 1 (automatically implies an upper bound of 1). */
     binaries?: Record<string, boolean | 0 | 1>;
+    /** Variables that may take negative values (by default, all variables are non-negative). */
     unrestricted?: Record<string, boolean | 0 | 1>;
+    /** Shorthand for `options.tolerance`. */
     tolerance?: number;
+    /** Shorthand for `options.timeout`. */
     timeout?: number;
+    /** Solver configuration options. */
     options?: SolveOptions;
+    /** Configuration for delegating to an external solver process (e.g., lp_solve). */
     external?: {
+        /** Name of the external solver to use (e.g., "lpsolve"). */
         solver: string;
         [key: string]: unknown;
     };
 }
 
+/**
+ * A decision variable in the optimization problem.
+ * Represents a quantity the solver can adjust to optimize the objective.
+ */
 export interface Variable {
+    /** Unique identifier for this variable. */
     id: string;
+    /** Objective function coefficient (contribution to the objective per unit). */
     cost: number;
+    /** Internal index in the tableau's variable arrays. */
     index: number;
+    /** Current value assigned by the solver. */
     value: number;
+    /** Priority level for hierarchical optimization (0 = primary objective). */
     priority: number;
+    /** Whether this variable must take an integer value. */
     isInteger?: boolean;
+    /** Whether this is a slack variable introduced for constraint conversion. */
     isSlack?: boolean;
 }
 
+/**
+ * A variable-coefficient pair representing one term in a linear expression.
+ */
 export interface Term {
+    /** The variable this term references. */
     variable: Variable;
+    /** The coefficient multiplying the variable. */
     coefficient: number;
 }
 
+/**
+ * A linear constraint in the optimization problem.
+ * Represents a linear inequality or equality over decision variables.
+ */
 export interface Constraint {
+    /** Slack variable added to convert inequality to equality for the tableau. */
     slack: Variable;
+    /** Internal index for the constraint in the tableau. */
     index: number;
+    /** Reference to the parent Model. */
     model: unknown;
+    /** Right-hand side value of the constraint. */
     rhs: number;
+    /** If true, constraint is <= (upper bound); if false, >= (lower bound). */
     isUpperBound: boolean;
+    /** All terms on the left-hand side of the constraint. */
     terms: Term[];
+    /** Fast lookup of terms by variable index. */
     termsByVarIndex: Record<number, Term>;
+    /** Relaxation variable for soft constraints (null if hard constraint). */
     relaxation: Variable | null;
 }
 
+/**
+ * A wrapped numeric value, used internally for expression building.
+ */
 export interface Numeral {
+    /** The numeric value. */
     value: number;
 }
 
+/**
+ * Simplified solution object returned by `solver.Solve()`.
+ *
+ * Contains feasibility status, optimal objective value, and the values
+ * of all non-zero decision variables as dynamic properties.
+ */
 export interface SolveResult {
+    /** Whether a feasible solution was found. */
     feasible: boolean;
+    /** Optimal objective function value (0 if infeasible). */
     result: number;
+    /** Whether the problem is bounded. False indicates unbounded objective. */
     bounded?: boolean;
+    /** Whether the solution satisfies all integrality constraints. */
     isIntegral?: boolean;
+    /** Decision variable values (only non-zero variables are included). */
     [variable: string]: number | boolean | undefined;
 }
 
-// Re-export external solver types
 export type { ExternalSolvers, ExternalSolverModule } from "../external/main";
 
-// Convenience type for typed solution access
+/**
+ * Type-safe solution access with known variable names.
+ * Extends SolveResult to provide typed access to specific variable values.
+ *
+ * @typeParam TVariable - Union of variable name string literals.
+ */
 export type Solution<TVariable extends string = string> = SolveResult &
     Record<TVariable, number | undefined>;
 
-// Full solver API type
+/** The full Solver class API type (useful for dependency injection). */
 export type SolverAPI = typeof import("../main").default;
 
-// Alias for backwards compatibility
+/** Alias for backwards compatibility with older API consumers. */
 export type ModelDefinition = Model;


### PR DESCRIPTION
## Summary
- Add comprehensive JSDoc documentation across all 22 source files (types, classes, methods, properties)
- Fix bug in `takeOutOfBase()` where column iteration used `this.height` instead of `this.width`, causing missed pivot columns when width > height (the common case)

## Bug fix details
`dynamic-modification.ts:55` — `takeOutOfBase` searches for a non-zero coefficient to pivot on by iterating columns, but the loop bound was `this.height` (number of rows) instead of `this.width` (number of columns). This truncated the search space on any problem with more variables than constraints.

## Performance impact
| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Total (47 problems) | 987 ms | 936 ms | -5.2% |
| Vendor Selection (heaviest) | 798 ms | 695 ms | -12.9% |

## Test plan
- [x] All 388 unit tests pass
- [x] All 24 stress tests pass
- [x] All 47 sanity profile problems produce correct feasibility results
- [x] Lint, format, typecheck, knip, depcruise all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)